### PR TITLE
Set isort profile to black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,6 @@ readme = {file = ["README.rst"]}
 
 [tool.setuptools.package-data]
 scwidgets = ["css/widgets.css"]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
It comes to clashes in formatting between isort and black otherwise (see https://stackoverflow.com/q/76038513)

<!-- readthedocs-preview scicode-widgets start -->
----
:books: Documentation preview :books:: https://scicode-widgets--13.org.readthedocs.build/en/13/

<!-- readthedocs-preview scicode-widgets end -->