### PR TITLE
Fixing W504 in __init__.py

### DIFF
--- a/src/scwidgets/__init__.py
+++ b/src/scwidgets/__init__.py
@@ -23,9 +23,7 @@ def get_css_style() -> HTML:
         style_txt = file.read()
 
     return HTML(
-        "HTML with scicode-widget css style sheet. \
-                Please keep this cell output alive. \
-                <style>"
-        + style_txt
-        + "</style>"
+        "HTML with scicode-widget css style sheet."
+        "Please keep this cell output alive."
+        "<style>" + style_txt + "</style>"
     )


### PR DESCRIPTION
I am not sure why this is not invoked, but in the PR https://github.com/osscar-org/scicode-widgets/pull/12 I got the linter error
https://www.flake8rules.com/rules/W504.html

<!-- readthedocs-preview scicode-widgets start -->
----
:books: Documentation preview :books:: https://scicode-widgets--15.org.readthedocs.build/en/15/

<!-- readthedocs-preview scicode-widgets end -->