### PR TITLE
Add CodeDemo and CodeInput

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dependencies = [
   "ipywidgets>=8.0.0",
   "numpy",
+  "widget_code_input",
 ]
 dynamic = ["version"]
 

--- a/src/scwidgets/code/__init__.py
+++ b/src/scwidgets/code/__init__.py
@@ -1,0 +1,6 @@
+from ._widget_code_demo import CodeDemo, CodeInput
+
+__all__ = [
+    "CodeDemo",
+    "CodeInput",
+]

--- a/src/scwidgets/code/_widget_code_demo.py
+++ b/src/scwidgets/code/_widget_code_demo.py
@@ -1,0 +1,163 @@
+import types
+from copy import deepcopy
+from platform import python_version
+from typing import Dict, List, Optional, Union
+
+from ipywidgets import HBox, Layout, Output, VBox
+from widget_code_input.utils import CodeValidationError
+
+from ..check import Check, CheckableWidget, CheckRegistry, ChecksLog
+from ..cue import CheckCueBox, ResetCueButton, UpdateCueBox
+from ._widget_code_input import CodeInput
+
+
+class CodeDemo(VBox, CheckableWidget):
+    """
+    A widget to demonstrate code interactively in a variety of ways. It is a combination
+    of the several widgets that allow to check check, run and visualize code.
+
+    :param code:
+        An or function or CodeInput that is usually the input of code for a student to
+        fill in a solution
+
+    :param check_registry:
+        a check registry that is used to register checks
+    """
+
+    def __init__(
+        self,
+        code: Union[CodeInput, types.FunctionType],  # TODO support of FunctionType
+        check_registry: Optional[CheckRegistry] = None,
+        parameters: Optional[Dict[str, Check.FunInParamT]] = None,
+        *args,
+        **kwargs,
+    ):
+        if isinstance(code, types.FunctionType):
+            code = CodeInput(function=code)
+
+        CheckableWidget.__init__(self, check_registry)
+
+        self._code = code
+        self._output = Output()
+        self._parameters = parameters
+        self._cue_code = self._code
+
+        if self._check_registry is None:
+            self._check_button = None
+            self._cue_check_button = None
+        else:
+            self._check_button = ResetCueButton(
+                [],
+                self._on_click_check_action,
+                description="Check Code",
+                disable_on_successful_action=False,
+                button_tooltip="Check the correctness of your code",
+            )
+            self._cue_code = CheckCueBox(
+                self._code, "function_body", self._cue_code, cued=True
+            )
+            self._cue_check_button = CheckCueBox(
+                self._code,
+                "function_body",
+                self._check_button,
+                cued=True,
+                layout=Layout(width="98%", height="auto"),
+            )
+            self._check_button.cue_boxes = [self._cue_code, self._cue_check_button]
+
+        if self._parameters is None:
+            self._update_button = None
+            self._cue_update_button = None
+        else:
+            self._update_button = ResetCueButton(
+                [],
+                self._on_click_update_action,
+                disable_on_successful_action=False,
+                description="Run Code",
+                button_tooltip="Runs the code with the specified parameters",
+            )
+            self._cue_code = UpdateCueBox(
+                self._code,
+                "function_body",
+                self._cue_code,
+                cued=True,
+                layout=Layout(width="98%", height="auto"),
+            )
+            self._cue_update_button = UpdateCueBox(
+                self._code, "function_body", self._update_button, cued=True
+            )
+            self._update_button.cue_boxes = [self._cue_code, self._cue_update_button]
+
+        if self._check_button is None and self._update_button is None:
+            self._buttons_panel = HBox([])
+        elif self._check_button is None:
+            self._buttons_panel = HBox([self._update_button])
+        elif self._update_button is None:
+            self._buttons_panel = HBox([self._check_button])
+        else:
+            self._buttons_panel = HBox(
+                [self._cue_check_button, self._cue_update_button]
+            )
+        VBox.__init__(
+            self, [self._cue_code, self._buttons_panel, self._output], *args, **kwargs
+        )
+
+    @property
+    def parameters(self):
+        return deepcopy(self._parameters)
+
+    def _on_click_update_action(self) -> bool:
+        try:
+            if self._parameters is None:
+                raise ValueError(
+                    "parameters is None but update action has been invoked, "
+                    "this is an invalid state and must be a bug in the initalization "
+                    "of the widget."
+                )
+            result = self.run_code(**self._parameters)
+            self._output_result(["Output:", str(result)])
+            return True
+        except Exception as e:
+            self._output_result([e])
+            return True
+
+    def _on_click_check_action(self) -> bool:
+        try:
+            result = self.check()
+        except Exception as e:
+            result = e
+        self.handle_checks_result(result)
+        return True
+
+    def compute_output_to_check(self, *args, **kwargs) -> Check.FunOutParamsT:
+        return self.run_code(*args, **kwargs)
+
+    def handle_checks_result(self, result: Union[ChecksLog, Exception]):
+        self._output_result([result])
+
+    def _output_result(self, results: List[Union[str, ChecksLog, Exception]]):
+        self._output.clear_output()
+        with self._output:
+            for result in results:
+                if isinstance(result, Exception):
+                    raise result
+                elif isinstance(result, ChecksLog):
+                    if result.successful:
+                        print("All checks were successful.")
+                    else:
+                        print("Some checks failed:")
+                        print(result.message())
+                else:
+                    print(result)
+
+    def run_code(self, *args, **kwargs) -> Check.FunOutParamsT:
+        try:
+            return self._code.run(*args, **kwargs)
+        except CodeValidationError as e:
+            raise e
+        except Exception as e:
+            # we give the student the additional information that this is most likely
+            # not because of his code
+            if python_version() >= "3.11":
+                e.add_note("This might might be not related to your code input.")
+            raise e

--- a/src/scwidgets/code/_widget_code_input.py
+++ b/src/scwidgets/code/_widget_code_input.py
@@ -1,0 +1,78 @@
+import inspect
+import re
+from typing import Callable
+
+from widget_code_input import WidgetCodeInput
+
+from ..check import Check
+
+
+class CodeInput(WidgetCodeInput):
+    """
+    Small wrapper around WidgetCodeInput that controls the output
+    """
+
+    def __init__(
+        self,
+        function=None,
+        function_name=None,
+        function_parameters=None,
+        docstring=None,
+        function_body=None,
+        code_theme="north",
+    ):
+        if function is not None:
+            function_name = (
+                function.__name__ if function_name is None else function_name
+            )
+            function_parameters = (
+                ", ".join(inspect.getfullargspec(function).args)
+                if function_parameters is None
+                else function_parameters
+            )
+            docstring = inspect.getdoc(function) if docstring is None else docstring
+            function_body = (
+                self.get_code(function) if function_body is None else function_body
+            )
+
+        # default parameters from WidgetCodeInput
+        if function_name is None:
+            raise ValueError("function_name must be given if no function is given.")
+        function_parameters = "" if function_parameters is None else function_parameters
+        docstring = "\n" if docstring is None else docstring
+        function_body = "" if function_body is None else function_body
+        super().__init__(
+            function_name, function_parameters, docstring, function_body, code_theme
+        )
+
+    def run(self, *args, **kwargs) -> Check.FunOutParamsT:
+        return self.get_function_object()(*args, **kwargs)
+
+    @staticmethod
+    def get_code(func: Callable):
+        source_lines, _ = inspect.getsourcelines(func)
+        for line in source_lines:
+            if "lambda" in line:
+                raise ValueError("Lambda functions are not supported.")
+
+        source = "".join(source_lines)
+
+        # Remove function definition
+        source = re.sub(r"^\s*def\s+[^\(]*\(.*\):.*?[;\n]", "", source)
+        # Remove docstrings
+        source = re.sub(
+            r"((.*?)\'\'\'(.*?)\'\'\'.*?[;\n]|(.*?)\"\"\"(.*?)\"\"\"(.*?)[;\n])",
+            "",
+            source,
+            flags=re.DOTALL,
+        )
+
+        # Adjust indentation
+        lines = source.split("\n")
+        if lines:
+            leading_indent = len(lines[0]) - len(lines[0].lstrip())
+            source = "\n".join(
+                line[leading_indent:] if line.strip() else "" for line in lines
+            )
+
+        return source

--- a/src/scwidgets/cue/_widget_cue_box.py
+++ b/src/scwidgets/cue/_widget_cue_box.py
@@ -1,10 +1,10 @@
 from typing import List, Optional, Union
 
-from ipywidgets import Box, Widget
+from ipywidgets import VBox, Widget
 from traitlets.utils.sentinel import Sentinel
 
 
-class CueBox(Box):
+class CueBox(VBox):
     """
     A box around the widget :param widget_to_cue: that adds a visual cue defined in the
     :param css_style: when the trait :param traits_to_observe: in the widget :param

--- a/tests/notebooks/widget_check_registry.py
+++ b/tests/notebooks/widget_check_registry.py
@@ -31,19 +31,11 @@ scwidgets.get_css_style()
 
 def create_check_registry(use_fingerprint, failing, buggy):
     check_registry = CheckRegistry()
-    checkable_widget = mock_checkable_widget(check_registry)
 
     check = single_param_check(
         use_fingerprint=use_fingerprint, failing=failing, buggy=buggy
     )
-    checkable_widget.compute_output_to_check = check.function_to_check
-
-    checkable_widget.add_check(
-        check.asserts,
-        check.inputs_parameters,
-        check.outputs_references,
-        check.fingerprint,
-    )
+    _ = mock_checkable_widget(check_registry, check.function_to_check, [check])
     return check_registry
 
 

--- a/tests/notebooks/widget_code_demo.py
+++ b/tests/notebooks/widget_code_demo.py
@@ -1,0 +1,46 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.15.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# +
+import os
+import sys
+
+import scwidgets
+
+sys.path.insert(0, os.path.abspath("../.."))
+from tests.test_check import single_param_check  # noqa: E402
+from tests.test_code import get_code_demo  # noqa: E402
+
+# -
+
+scwidgets.get_css_style()
+
+
+def run_code_demo(checks):
+    return get_code_demo(checks)
+
+
+# Test 1:
+# -------
+# Test if CodeDemo shows correct output
+
+# Test 1.1
+run_code_demo([single_param_check(use_fingerprint=False, failing=False, buggy=False)])
+
+# Test 1.2
+run_code_demo([single_param_check(use_fingerprint=False, failing=True, buggy=False)])
+
+# Test 1.3
+run_code_demo([single_param_check(use_fingerprint=False, failing=False, buggy=True)])

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,0 +1,167 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.15.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+from typing import List
+
+import pytest
+from widget_code_input.utils import CodeValidationError
+
+from scwidgets.check import Check, CheckRegistry, ChecksLog
+from scwidgets.code import CodeDemo, CodeInput
+
+from .test_check import multi_param_check, single_param_check
+
+
+class TestCodeInput:
+    @staticmethod
+    def mock_function_1(x, y):
+        """
+        This is an example function.
+        It adds two numbers.
+        """
+        if x > 0:
+            return x + y
+        else:
+            return y
+
+    @staticmethod
+    def mock_function_2(x):
+        """This is an example function. It adds two numbers."""
+        return x
+
+    @staticmethod
+    def mock_function_3(x):
+        """This returns identity"""
+        return x
+
+    @staticmethod
+    def mock_function_4(x):
+        """This returns identity"""
+        return x
+
+    def test_get_code(self):
+        assert (
+            CodeInput.get_code(self.mock_function_1)
+            == "if x > 0:\n    return x + y\nelse:\n    return y\n"
+        )
+        assert CodeInput.get_code(self.mock_function_2) == "return x\n"
+        assert CodeInput.get_code(self.mock_function_3) == "return x\n"
+        assert CodeInput.get_code(self.mock_function_4) == "return x\n"
+        with pytest.raises(
+            ValueError,
+            match=r"Lambda functions are not supported.",
+        ):
+            CodeInput.get_code(lambda x: x)
+
+
+def get_code_demo(checks: List[Check]):
+    # Important:
+    # we take the the function_to_check from the first check as code input
+    code_input = CodeInput(checks[0].function_to_check)
+    code_demo = CodeDemo(
+        code=code_input,
+        check_registry=CheckRegistry(),
+        parameters=checks[0].inputs_parameters[0],
+    )
+    for check in checks:
+        code_demo.add_check(
+            check.asserts,
+            check.inputs_parameters,
+            check.outputs_references,
+            check.fingerprint,
+        )
+    return code_demo
+
+
+class TestCodeDemo:
+    @pytest.mark.parametrize(
+        "code_demo",
+        [
+            get_code_demo(
+                [single_param_check(use_fingerprint=False, failing=False, buggy=False)]
+            ),
+            get_code_demo(
+                [
+                    single_param_check(
+                        use_fingerprint=False, failing=False, buggy=False
+                    ),
+                    single_param_check(
+                        use_fingerprint=True, failing=False, buggy=False
+                    ),
+                ]
+            ),
+            get_code_demo([multi_param_check(use_fingerprint=False, failing=False)]),
+            get_code_demo([multi_param_check(use_fingerprint=True, failing=False)]),
+        ],
+    )
+    def test_successful_check_widget(self, code_demo):
+        result = code_demo.check()
+        assert isinstance(result, ChecksLog)
+        assert result.successful
+        assert len(result.assert_results) == code_demo.nb_conducted_asserts
+
+    @pytest.mark.parametrize(
+        "code_demo",
+        [
+            get_code_demo(
+                [single_param_check(use_fingerprint=False, failing=True, buggy=False)]
+            ),
+            get_code_demo(
+                [
+                    single_param_check(
+                        use_fingerprint=False, failing=True, buggy=False
+                    ),
+                    single_param_check(use_fingerprint=True, failing=True, buggy=False),
+                ]
+            ),
+            get_code_demo([multi_param_check(use_fingerprint=False, failing=True)]),
+            get_code_demo([multi_param_check(use_fingerprint=True, failing=True)]),
+        ],
+    )
+    def test_compute_and_set_references(self, code_demo):
+        code_demo.compute_and_set_references()
+
+        result = code_demo.check()
+        assert isinstance(result, ChecksLog)
+        assert result.successful
+        assert len(result.assert_results) == code_demo.nb_conducted_asserts
+
+    @pytest.mark.parametrize(
+        "code_demo",
+        [
+            get_code_demo(
+                [single_param_check(use_fingerprint=False, failing=False, buggy=False)]
+            ),
+            get_code_demo([multi_param_check(use_fingerprint=False, failing=False)]),
+        ],
+    )
+    def test_run_code(self, code_demo):
+        output = code_demo.run_code(**code_demo.checks[0].inputs_parameters[0])
+        assert output == code_demo.checks[0].outputs_references[0]
+
+    @pytest.mark.parametrize(
+        "code_demo",
+        [
+            get_code_demo(
+                [single_param_check(use_fingerprint=False, failing=False, buggy=True)]
+            ),
+        ],
+    )
+    def test_erroneous_run_code(self, code_demo):
+        with pytest.raises(
+            CodeValidationError,
+            match="NameError in code input: name 'bug' is not defined.*",
+        ):
+            code_demo.run_code(**code_demo.checks[0].inputs_parameters[0])

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -17,11 +17,12 @@ def test_notebook_running(notebook_service):
 
 
 CUE_BOX_CLASS_NAME = (
-    "lm-Widget.lm-Panel.jupyter-widgets.widget-container" ".widget-box.scwidget-cue-box"
+    "lm-Widget.lm-Panel.jupyter-widgets.widget-container"
+    ".widget-box.widget-vbox.scwidget-cue-box"
 )
 CUED_CUE_BOX_CLASS_NAME = (
     "lm-Widget.lm-Panel.jupyter-widgets.widget-container"
-    ".widget-box.scwidget-cue-box.scwidget-cue-box--cue"
+    ".widget-box.widget-vbox.scwidget-cue-box.scwidget-cue-box--cue"
 )
 
 


### PR DESCRIPTION
CodeInput is a wrapper around WidgetCodeInput that also accepts a function as input

TODO:
- [x] first merge CheckRegistry and Checks
- [x] mv `CodeInput` and `Code` dedicated module `code` into a file `_widget_code_input.py` and  `_widget_code_demo.py`
- [x] widget tests


<!-- readthedocs-preview scicode-widgets start -->
----
:books: Documentation preview :books:: https://scicode-widgets--17.org.readthedocs.build/en/17/

<!-- readthedocs-preview scicode-widgets end -->