### PR TITLE
Add coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+    patch:
+      default:
+        target: 80%
+
+comment: on

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,11 @@ jobs:
 
     - name: run Python tests
       run: tox -e tests
+
+    - name: run Python tests for coverage
+      run: tox -e coverage
+    - uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml
+        verbose: true
+

--- a/src/scwidgets/cue/_widget_reset_cue_button.py
+++ b/src/scwidgets/cue/_widget_reset_cue_button.py
@@ -55,7 +55,7 @@ class ResetCueButton(Button):
             )
             self.disabled = not (self._cue_boxes[0].cued)
 
-        self.on_click(self._reset_on_successful_action)
+        self.on_click(self._on_click_reset_on_successful_action)
 
     @property
     def cue_boxes(self):
@@ -100,7 +100,7 @@ class ResetCueButton(Button):
     def disable_on_successful_action(self, disable_on_successful_action: bool):
         self._disable_on_successful_action = disable_on_successful_action
 
-    def _reset_on_successful_action(self, button: Button):
+    def _on_click_reset_on_successful_action(self, button: Button):
         success = self._action()
         if success:
             for cue_box in self._cue_boxes:

--- a/tests/notebooks/widget_check_registry.py
+++ b/tests/notebooks/widget_check_registry.py
@@ -20,16 +20,16 @@ import sys
 import scwidgets
 from scwidgets.check import CheckRegistry
 
-sys.path.insert(0, os.path.abspath(".."))
-from test_check import mock_checkable_widget  # noqa: E402
-from test_check import single_param_check  # noqa: E402
+sys.path.insert(0, os.path.abspath("../.."))
+from tests.test_check import mock_checkable_widget  # noqa: E402
+from tests.test_check import single_param_check  # noqa: E402
 
 # -
 
 scwidgets.get_css_style()
 
 
-def test_check_registry(use_fingerprint, failing, buggy):
+def create_check_registry(use_fingerprint, failing, buggy):
     check_registry = CheckRegistry()
     checkable_widget = mock_checkable_widget(check_registry)
 
@@ -52,16 +52,16 @@ def test_check_registry(use_fingerprint, failing, buggy):
 # Test if CheckRegistry shows correct output
 
 # Test 1.1
-test_check_registry(use_fingerprint=False, failing=False, buggy=False)
+create_check_registry(use_fingerprint=False, failing=False, buggy=False)
 
 # Test 1.2
-test_check_registry(use_fingerprint=True, failing=False, buggy=False)
+create_check_registry(use_fingerprint=True, failing=False, buggy=False)
 
 # Test 1.3
-test_check_registry(use_fingerprint=False, failing=True, buggy=False)
+create_check_registry(use_fingerprint=False, failing=True, buggy=False)
 
 # Test 1.4
-test_check_registry(use_fingerprint=True, failing=True, buggy=False)
+create_check_registry(use_fingerprint=True, failing=True, buggy=False)
 
 # Test 1.5
-test_check_registry(use_fingerprint=False, failing=False, buggy=True)
+create_check_registry(use_fingerprint=False, failing=False, buggy=True)

--- a/tests/notebooks/widgets_cue.py
+++ b/tests/notebooks/widgets_cue.py
@@ -27,26 +27,26 @@ scwidgets.get_css_style()
 # Check if CueBox shows cue when changed
 
 
-def test_1(CueBoxClass, cued):
+def create_cue_box(CueBoxClass, cued):
     text_input = Text("Text")
     cued_text_input = CueBoxClass(text_input, cued=cued)
     return cued_text_input
 
 
 # Test 1.1
-test_1(CueBox, True)
+create_cue_box(CueBox, True)
 
 # Test 1.2
-test_1(CueBox, False)
+create_cue_box(CueBox, False)
 
 # Test 1.3
-test_1(SaveCueBox, False)
+create_cue_box(SaveCueBox, False)
 
 # Test 1.4
-test_1(CheckCueBox, False)
+create_cue_box(CheckCueBox, False)
 
 # Test 1.5
-test_1(UpdateCueBox, False)
+create_cue_box(UpdateCueBox, False)
 
 # Test 2:
 # -------

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,11 @@ commands =
 
 commands_post =
     coverage xml
+    coverage html
+
+[coverage:report]
+exclude_also =
+    def _on
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -19,17 +19,33 @@ setenv =
     JUPYTER_CONFIG_DIR={envdir}/etc/jupyter
     JUPYTER_DATA_DIR={envdir}/share/jupyter
 deps =
-    notebook==7.0.2
     pytest
+    # selenium juypter notebook tests
+    notebook==7.0.2
     # fixing selenium version to have backwards-compatibility with pytest-selenium
     # see https://github.com/robotframework/SeleniumLibrary/issues/1835#issuecomment-1581426365
-    selenium==4.9.0 
+    selenium==4.9.0
     pytest-selenium
     jupytext==1.15.0
 commands =
     # converts the python files to ipython notebooks
     jupytext tests/notebooks/*.py --to ipynb
     pytest {posargs:-s -v} --driver Firefox
+
+[testenv:coverage]
+# We do coverage in a separate environment that skips the selenium tests but
+# includes the jupytext notebook files, because coverage is incompatible with
+# selenium
+deps =
+    pytest
+    pytest-cov
+    coverage[toml]
+    selenium==4.9.0
+commands =
+   pytest --cov=scwidgets --ignore=tests/test_widgets.py -o testpaths="tests tests/notebooks/*py"
+
+commands_post =
+    coverage xml
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
One big problem with the coverage is that the tests for the widgets are not recorded by the coverage. First I thought this is just because they are executed within a subprocess for which coverage has a solution https://coverage.readthedocs.io/en/latest/subprocess.html, but it is actually more related to how python code is executed in a notebook. There exist a package `pytest-notebook` that supports coverage for notebooks, but I could not get it merge with our framework without much extra effort. In the end it also cannot record the code that is executed when using selenium to pass user interactions (e.g. button clicks), because it uses nbclient that runs the notebook a different execution context (which AFAIK does not really load UI elements). So I will just run the python scripts that are converted to notebooks that does the same job and is much simpler. I still need to figure to which degree I add exclude patterns to coverage, because the on_click actions cannot be recorded coverage. If all functions that are used for such interactions have a standardized name we can exclude them very easily. I need still to check this.

<!-- readthedocs-preview scicode-widgets start -->
----
:books: Documentation preview :books:: https://scicode-widgets--18.org.readthedocs.build/en/18/

<!-- readthedocs-preview scicode-widgets end -->