### PR TITLE
Update message

### DIFF
--- a/src/scwidgets/_utils.py
+++ b/src/scwidgets/_utils.py
@@ -1,16 +1,56 @@
+import re
+
 from termcolor import colored
 
 
 class Printer:
-    # move to output
+    # TODO rename to Formatter
+    #      remove print funcs
+    LINE_LENGTH = 120
+    INFO_COLOR = "blue"
+    ERROR_COLOR = "red"
+    SUCCESS_COLOR = "green"
+
+    @staticmethod
+    def format_title_message(message: str) -> str:
+        return message.center(Printer.LINE_LENGTH - len(message) // 2, "-")
+
+    @staticmethod
+    def break_lines(message: str) -> str:
+        return "\n ".join(re.findall(r".{1," + str(Printer.LINE_LENGTH) + "}", message))
+
+    @staticmethod
+    def color_error_message(message: str) -> str:
+        return colored(message, Printer.ERROR_COLOR, attrs=["bold"])
+
     @staticmethod
     def print_error_message(message: str):
-        print(colored(message, "red", attrs=["bold"]))
+        print(Printer.color_error_message(message))
+
+    @staticmethod
+    def color_success_message(message: str) -> str:
+        return colored(message, Printer.SUCCESS_COLOR, attrs=["bold"])
 
     @staticmethod
     def print_success_message(message: str):
-        print(colored(message, "green", attrs=["bold"]))
+        print(Printer.color_success_message(message))
+
+    @staticmethod
+    def color_info_message(message: str):
+        return colored(message, Printer.INFO_COLOR, attrs=["bold"])
 
     @staticmethod
     def print_info_message(message: str):
-        print(colored(message, "blue", attrs=["bold"]))
+        print(Printer.color_info_message(message))
+
+    @staticmethod
+    def color_assert_failed(message: str) -> str:
+        return colored(message, "light_" + Printer.ERROR_COLOR)
+
+    @staticmethod
+    def color_assert_info(message: str) -> str:
+        return colored(message, "light_" + Printer.INFO_COLOR)
+
+    @staticmethod
+    def color_assert_success(message: str) -> str:
+        return colored(message, "light_" + Printer.SUCCESS_COLOR)

--- a/src/scwidgets/check/__init__.py
+++ b/src/scwidgets/check/__init__.py
@@ -5,12 +5,13 @@ from ._asserts import (
     assert_shape,
     assert_type,
 )
-from ._check import Check, ChecksLog
+from ._check import AssertResult, Check, ChecksLog
 from ._widget_check_registry import CheckableWidget, CheckRegistry
 
 __all__ = [
     "Check",
     "ChecksLog",
+    "AssertResult",
     "CheckRegistry",
     "CheckableWidget",
     "assert_shape",

--- a/src/scwidgets/code/_widget_code_demo.py
+++ b/src/scwidgets/code/_widget_code_demo.py
@@ -142,7 +142,7 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
         elif not (isinstance(cue_outputs, list)):
             cue_outputs = [cue_outputs]
 
-        CheckableWidget.__init__(self, check_registry)
+        CheckableWidget.__init__(self, check_registry, answer_key)
         AnswerWidget.__init__(self, answer_registry, answer_key)
 
         self._code = code
@@ -564,9 +564,12 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
                 raise result
             elif isinstance(result, ChecksLog):
                 if result.successful:
-                    Printer.print_success_message("Check was successful.")
+                    Printer.print_success_message("Check was successful")
+                    Printer.print_success_message("--------------------")
+                    print(result.message())
                 else:
-                    Printer.print_error_message("Check failed:")
+                    Printer.print_error_message("Check failed")
+                    Printer.print_error_message("------------")
                     print(result.message())
             else:
                 print(result)

--- a/src/scwidgets/cue/_widget_cue_object.py
+++ b/src/scwidgets/cue/_widget_cue_object.py
@@ -35,7 +35,7 @@ class CueObject(CueOutput):
 
     def __init__(
         self,
-        display_object: Any,
+        display_object: Any = None,
         widgets_to_observe: Union[None, List[Widget], Widget] = None,
         traits_to_observe: Union[
             None, str, List[str], List[List[str]], Sentinel

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -19,7 +19,7 @@ def test_assert_shape():
     output_parameters = (np.array([1, 2, 3]),)
     output_references = (np.array([1, 2, 3]),)
     result = assert_shape(output_parameters, output_references)
-    assert result == ""
+    assert result.successful
 
 
 def test_assert_invalid_parameters_to_check():
@@ -33,29 +33,28 @@ def test_assert_numpy_allclose():
     output_parameters = (np.array([1.0, 2.0]),)
     output_references = (np.array([1.1, 2.2]),)
     result = assert_numpy_allclose(output_parameters, output_references)
-    assert "Output parameter 0 is not close to reference" in result
+    assert "Output is not close to reference" in result.message()
 
 
 def test_assert_type():
     output_parameters = (42,)
     output_references = (42,)
     result = assert_type(output_parameters, output_references)
-    assert result == ""
+    assert result.successful
 
 
 def test_assert_numpy_floating_sub_dtype():
     output_parameters = (np.array([1.0, 2.0]),)
     result = assert_numpy_floating_sub_dtype(output_parameters)
-    assert result == ""
+    assert result.successful
 
 
 def test_assert_invalid_output_parameter_dtype():
     output_parameters = (np.array([1, 2]),)
     result = assert_numpy_floating_sub_dtype(output_parameters)
-    assert result == (
-        "Output parameter 0 expected to be sub dtype numpy.floating "
-        "but got numpy.int64."
-    )
+    assert (
+        "Output expected to be sub dtype numpy.floating " "but got numpy.int64."
+    ) in result.message()
 
 
 def single_param_check(use_fingerprint=False, failing=False, buggy=False):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -934,33 +934,33 @@ def test_widget_check_registry(selenium_driver):
     # Test 1.1 use_fingerprint=False, failing=False, buggy=False
     test_button_clicks(
         nb_cells[3],
-        "Widget 1 all checks were successful.",
-        "Successfully set all references.",
-        "Widget 1 all checks were successful.",
+        "Widget 1 all checks were successful",
+        "Successfully set all references",
+        "Widget 1 all checks were successful",
     )
 
     # Test 1.2 use_fingerprint=True, failing=False, buggy=False
     test_button_clicks(
         nb_cells[4],
-        "Widget 1 all checks were successful.",
-        "Successfully set all references.",
-        "Widget 1 all checks were successful.",
+        "Widget 1 all checks were successful",
+        "Successfully set all references",
+        "Widget 1 all checks were successful",
     )
 
     # Test 1.3 use_fingerprint=False, failing=False, buggy=False
     test_button_clicks(
         nb_cells[5],
         "Widget 1 not all checks were successful",
-        "Successfully set all references.",
-        "Widget 1 all checks were successful.",
+        "Successfully set all references",
+        "Widget 1 all checks were successful",
     )
 
     # Test 1.4 use_fingerprint=False, failing=False, buggy=False
     test_button_clicks(
         nb_cells[6],
         "Widget 1 not all checks were successful",
-        "Successfully set all references.",
-        "Widget 1 all checks were successful.",
+        "Successfully set all references",
+        "Widget 1 all checks were successful",
     )
 
     # Test 1.5 use_fingerprint=False, failing=False, buggy=True


### PR DESCRIPTION
Reopen of https://github.com/osscar-org/scicode-widgets/pull/26#issue-1877632820 because I accidentally push main to the branch and not the HEAD

* implement AssertResult that allows formatting of assert
  results
* use answer_key as CheckableWidget name
* handle error during check more transparent to student by catching
  errors during fingerprint function and asserts and embedding them into
  the assert message
* implement input parameters for Checks
  - suppress_fingerprint_asserts: specifies if the assert messages that
    use the fingerprint function result are suppressed
  - stop_on_assert_error_raised: Specifies if running the asserts is
    stopped as soon as an error is raised in an assert
* format check results more structured


<!-- readthedocs-preview scicode-widgets start -->
----
:books: Documentation preview :books:: https://scicode-widgets--30.org.readthedocs.build/en/30/

<!-- readthedocs-preview scicode-widgets end -->