### PR TITLE
Add exercise description and title

### DIFF
--- a/src/scwidgets/answer/_widget_answer_registry.py
+++ b/src/scwidgets/answer/_widget_answer_registry.py
@@ -260,9 +260,6 @@ class AnswerRegistry(VBox):
         dropdown_options = self._get_dropdown_options()
         self._answers_files_dropdown.options = dropdown_options
 
-        dropdown_options = self._get_dropdown_options()
-        self._answers_files_dropdown.options = dropdown_options
-
     @property
     def registered_widgets(self):
         return self._widgets.copy()

--- a/src/scwidgets/code/_widget_code_demo.py
+++ b/src/scwidgets/code/_widget_code_demo.py
@@ -6,7 +6,7 @@ import types
 from platform import python_version
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from ipywidgets import Box, HBox, Layout, VBox, Widget
+from ipywidgets import HTML, Box, HBox, HTMLMath, Layout, VBox, Widget
 from widget_code_input.utils import CodeValidationError
 
 from .._utils import Printer
@@ -68,6 +68,8 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
         update_func: Optional[
             Callable[[CodeDemo], Union[Any, Check.FunOutParamsT]]
         ] = None,
+        exercise_description: Optional[str] = None,
+        exercise_title: Optional[str] = None,
         *args,
         **kwargs,
     ):
@@ -80,6 +82,27 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
         self._update_mode = update_mode
 
         self._update_func = update_func
+
+        self._exercise_description = exercise_description
+        if exercise_description is None:
+            self._exercise_description_html = None
+        else:
+            self._exercise_description_html = HTMLMath(self._exercise_description)
+        if exercise_title is None:
+            if answer_key is None:
+                self._exercise_title = None
+                self._exercise_title_html = None
+            else:
+                self._exercise_title = answer_key
+                self._exercise_title_html = HTML(f"<b>{answer_key}</b>")
+        else:
+            self._exercise_title = exercise_title
+            self._exercise_title_html = HTML(f"<b>{exercise_title}</b>")
+
+        if self._exercise_description_html is not None:
+            self._exercise_description_html.add_class("exercise-description")
+        if self._exercise_title_html is not None:
+            self._exercise_title_html.add_class("exercise-title")
 
         # verify if input argument `parameter` is valid
         if parameters is not None:
@@ -372,6 +395,11 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
             )
 
         demo_children = []
+        if self._exercise_title_html is not None:
+            demo_children.append(self._exercise_title_html)
+        if self._exercise_description_html is not None:
+            demo_children.append(self._exercise_description_html)
+
         if self._cue_code is not None:
             demo_children.append(self._cue_code)
         if self._cue_parameter_panel is not None:
@@ -452,6 +480,14 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
             parameter_panel = self._parameter_panel
             return parameter_panel.parameters
         return {}
+
+    @property
+    def exercise_title(self) -> Union[str, None]:
+        return self._exercise_title
+
+    @property
+    def exercise_description(self) -> Union[str, None]:
+        return self._exercise_description
 
     def _on_trait_parameters_changed(self, change: dict):
         if self._update_button is None:

--- a/src/scwidgets/css/widgets.css
+++ b/src/scwidgets/css/widgets.css
@@ -111,3 +111,22 @@
 .scwidget-cue-output--cue {
     opacity: 0.4;
 }
+
+.exercise-title {
+  font-family: helvetica;
+  font-size: 150%;
+}
+.exercise-description {
+  font-family: helvetica;
+  font-size: 110%;
+  color: black;
+  word-spacing: 2px;
+}
+
+a {
+  color: blue;
+}
+
+a:hover {
+  color: lightblue;
+}

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 import requests
 from imageio.v3 import imread
-from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webelement import WebElement
@@ -362,12 +361,7 @@ class TestAnswerWidgets:
         #
         WebDriverWait(driver, 1).until(
             expected_conditions.element_to_be_clickable(save_button)
-        )
-        WebDriverWait(driver, 1).until(
-            expected_conditions.element_to_be_clickable(save_button)
-        )
-        # save button is hidden so we use actions to click
-        ActionChains(driver).move_to_element(save_button).click(save_button).perform()
+        ).click()
         # wait for uncued box
         cue_box = nb_cell.find_element(By.CLASS_NAME, cue_box_class_name("save", False))
         assert "--cued" not in cue_box.get_attribute("class")


### PR DESCRIPTION
This allows to add a preamble to the CodeDemo and exercise.Textarea by the argument exercise_description. The answer key is used as title if None is given.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview scicode-widgets end -->