### PR TITLE
Fix jupyter lab wrong number of of matplotlib canvases

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -576,6 +576,11 @@ def test_widget_figure(selenium_driver, nb_filename, mpl_backend):
             # in the notebook an image of the python logo is shown as first canvas, so
             # we remove it
             matplotlib_canvases = matplotlib_canvases[1:]
+        elif JUPYTER_TYPE == "lab":
+            # sometimes another canvas is shown that we filter out
+            matplotlib_canvases = [
+                canvas for canvas in matplotlib_canvases if canvas.is_displayed()
+            ]
 
         assert (
             len(matplotlib_canvases) >= nb_expected_canvases


### PR DESCRIPTION
Sometimes in jupyter lab 5 canvases exist, one is not displayable and can be ignored. In this fix we filter out all canvases that are not displayable.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--36.org.readthedocs.build/en/36/

<!-- readthedocs-preview scicode-widgets end -->