### PR TITLE
Restructure exercise submodule

### DIFF
--- a/src/scwidgets/code/__init__.py
+++ b/src/scwidgets/code/__init__.py
@@ -1,9 +1,7 @@
-from ._widget_code_demo import CodeDemo
 from ._widget_code_input import CodeInput
 from ._widget_parameter_panel import ParameterPanel
 
 __all__ = [
-    "CodeDemo",
     "CodeInput",
     "ParameterPanel",
 ]

--- a/src/scwidgets/code/_widget_parameter_panel.py
+++ b/src/scwidgets/code/_widget_parameter_panel.py
@@ -14,7 +14,7 @@ class ParameterPanel(VBox):
     :param parameters:
         Can be any input that is allowed as keyword arguments in ipywidgets.interactive
         for the parameters. _options and other widget layout parameter are controlled
-        by CodeDemo.
+        by CodeExercise.
 
     """
 
@@ -25,7 +25,8 @@ class ParameterPanel(VBox):
         if "_option" in parameters.keys():
             raise ValueError(
                 "Found interactive argument `_option` in paramaters, but "
-                "CodeDemo controls this parameter to ensure correct initialization."
+                "ParameterPanels should be controled by an exercise widget "
+                "to ensure correct initialization."
             )
 
         # we use a dummy function because interactive executes it once on init

--- a/src/scwidgets/exercise/__init__.py
+++ b/src/scwidgets/exercise/__init__.py
@@ -1,3 +1,3 @@
-from ._widget_textarea import Textarea
+from ._widget_text_exercise import TextExercise
 
-__all__ = ["Textarea"]
+__all__ = ["TextExercise"]

--- a/src/scwidgets/exercise/__init__.py
+++ b/src/scwidgets/exercise/__init__.py
@@ -1,3 +1,4 @@
+from ._widget_code_exercise import CodeExercise
 from ._widget_text_exercise import TextExercise
 
-__all__ = ["TextExercise"]
+__all__ = ["CodeExercise", "TextExercise"]

--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -12,6 +12,8 @@ from widget_code_input.utils import CodeValidationError
 from .._utils import Formatter
 from ..answer import AnswerRegistry, AnswerWidget
 from ..check import Check, CheckableWidget, CheckRegistry, ChecksResult
+from ..code._widget_code_input import CodeInput
+from ..code._widget_parameter_panel import ParameterPanel
 from ..cue import (
     CheckCueBox,
     CheckResetCueButton,
@@ -21,11 +23,9 @@ from ..cue import (
     UpdateCueBox,
     UpdateResetCueButton,
 )
-from ._widget_code_input import CodeInput
-from ._widget_parameter_panel import ParameterPanel
 
 
-class CodeDemo(VBox, CheckableWidget, AnswerWidget):
+class CodeExercise(VBox, CheckableWidget, AnswerWidget):
     """
     A widget to demonstrate code interactively in a variety of ways. It is a combination
     of the several widgets that allow to check check, run and visualize code.
@@ -50,7 +50,7 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
 
     :param update_func:
         A function that is run during the update process. The function takes as argument
-        the CodeDemo, so it can update all cue_ouputs
+        the CodeExercise, so it can update all cue_ouputs
 
     """
 
@@ -66,7 +66,7 @@ class CodeDemo(VBox, CheckableWidget, AnswerWidget):
         update_mode: str = "release",
         cue_outputs: Union[None, CueOutput, List[CueOutput]] = None,
         update_func: Optional[
-            Callable[[CodeDemo], Union[Any, Check.FunOutParamsT]]
+            Callable[[CodeExercise], Union[Any, Check.FunOutParamsT]]
         ] = None,
         exercise_description: Optional[str] = None,
         exercise_title: Optional[str] = None,

--- a/src/scwidgets/exercise/_widget_text_exercise.py
+++ b/src/scwidgets/exercise/_widget_text_exercise.py
@@ -1,14 +1,13 @@
 from typing import Optional, Union
 
-import ipywidgets
-from ipywidgets import HTML, HBox, HTMLMath, Layout, Output, VBox
+from ipywidgets import HTML, HBox, HTMLMath, Layout, Output, Textarea, VBox
 
 from .._utils import Formatter
 from ..answer import AnswerRegistry, AnswerWidget
 from ..cue import SaveCueBox, SaveResetCueButton
 
 
-class Textarea(VBox, AnswerWidget):
+class TextExercise(VBox, AnswerWidget):
     """
     :param textarea:
         a custom textarea with custom styling, if not specified the standard parameters
@@ -49,7 +48,7 @@ class Textarea(VBox, AnswerWidget):
             self._exercise_title_html.add_class("exercise-title")
 
         layout = kwargs.pop("layout", Layout(width="auto", height="150px"))
-        self._textarea = ipywidgets.Textarea(value, *args, layout=layout, **kwargs)
+        self._textarea = Textarea(value, *args, layout=layout, **kwargs)
         self._cue_textarea = self._textarea
         self._output = Output()
 

--- a/tests/notebooks/widget_answers.py
+++ b/tests/notebooks/widget_answers.py
@@ -20,7 +20,7 @@ import sys
 import scwidgets
 from scwidgets.answer import AnswerRegistry
 from scwidgets.code import CodeDemo
-from scwidgets.exercise import Textarea
+from scwidgets.exercise import TextExercise
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -39,10 +39,10 @@ answer_registry
 
 # Test 2:
 # -------
-# Test if Textarea shows correct output
+# Test if TextExercise shows correct output
 
-textarea = Textarea(answer_registry=answer_registry, answer_key="exercise_1")
-textarea
+text_exercise = TextExercise(answer_registry=answer_registry, answer_key="exercise_1")
+text_exercise
 
 # Test 3:
 # -------

--- a/tests/notebooks/widget_answers.py
+++ b/tests/notebooks/widget_answers.py
@@ -19,8 +19,7 @@ import sys
 
 import scwidgets
 from scwidgets.answer import AnswerRegistry
-from scwidgets.code import CodeDemo
-from scwidgets.exercise import TextExercise
+from scwidgets.exercise import CodeExercise, TextExercise
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -46,7 +45,7 @@ text_exercise
 
 # Test 3:
 # -------
-# Test if CodeDemo shows correct output
+# Test if CodeExercise shows correct output
 
 
 # +
@@ -54,12 +53,12 @@ def foo(x):
     return x
 
 
-code_demo = CodeDemo(
+code_ex = CodeExercise(
     foo,
     parameters={"x": (0, 2, 1)},
     update_mode="manual",
     answer_registry=answer_registry,
     answer_key="exercise_2",
 )
-code_demo
+code_ex
 # -

--- a/tests/notebooks/widget_code_exercise.py
+++ b/tests/notebooks/widget_code_exercise.py
@@ -21,7 +21,7 @@ import scwidgets
 
 sys.path.insert(0, os.path.abspath("../.."))
 from tests.test_check import single_param_check  # noqa: E402
-from tests.test_code import get_code_demo  # noqa: E402
+from tests.test_code import get_code_exercise  # noqa: E402
 
 # -
 
@@ -29,10 +29,10 @@ scwidgets.get_css_style()
 
 # Test 1:
 # -------
-# Test if CodeDemo shows correct output
+# Test if CodeExercise shows correct output
 
 # Test 1.1
-get_code_demo(
+get_code_exercise(
     [single_param_check(use_fingerprint=False, failing=False, buggy=False)],
     include_checks=True,
     include_params=True,
@@ -41,7 +41,7 @@ get_code_demo(
 )
 
 # Test 1.2
-get_code_demo(
+get_code_exercise(
     [single_param_check(use_fingerprint=False, failing=True, buggy=False)],
     include_checks=True,
     include_params=True,
@@ -50,7 +50,7 @@ get_code_demo(
 )
 
 # Test 1.3
-get_code_demo(
+get_code_exercise(
     [single_param_check(use_fingerprint=False, failing=False, buggy=True)],
     include_checks=True,
     include_params=True,
@@ -59,7 +59,7 @@ get_code_demo(
 )
 
 # Test 1.4
-get_code_demo(
+get_code_exercise(
     [single_param_check(use_fingerprint=False, failing=False, buggy=False)],
     include_checks=True,
     include_params=True,
@@ -68,7 +68,7 @@ get_code_demo(
 )
 
 # Test 1.5
-get_code_demo(
+get_code_exercise(
     [single_param_check(use_fingerprint=False, failing=False, buggy=False)],
     include_checks=True,
     include_params=True,
@@ -77,7 +77,7 @@ get_code_demo(
 )
 
 # Test 1.6
-get_code_demo(
+get_code_exercise(
     [single_param_check(use_fingerprint=False, failing=False, buggy=False)],
     include_checks=True,
     include_params=True,
@@ -88,7 +88,7 @@ get_code_demo(
 
 # Test 2:
 # -------
-# Test if CodeDemo works correct for only update
+# Test if CodeExercise works correct for only update
 
 
 # +
@@ -99,7 +99,7 @@ def function_to_check():
     return 5
 
 
-get_code_demo(
+get_code_exercise(
     [],
     code=function_to_check,
     include_checks=False,
@@ -111,25 +111,39 @@ get_code_demo(
 
 # Test 2.2
 # TODO
-# get_code_demo([single_param_check(use_fingerprint=False, failing=True, buggy=False)],
-#        include_checks=False, include_params=True, tunable_params)
+# get_code_exercise(
+#    [single_param_check(use_fingerprint=False, failing=True, buggy=False)],
+#    include_checks=False,
+#    include_params=True,
+#    tunable_params=True,
+# )
 
 # Test 2.3
 # TODO
-# get_code_demo([single_param_check(use_fingerprint=True, failing=True, buggy=False)],
-#        include_checks=False, include_params=True, tunable_params)
+# get_code_exercise(
+#    [single_param_check(use_fingerprint=True, failing=True, buggy=False)],
+#    include_checks=False,
+#    include_params=True,
+#    tunable_params=True,
+# )
 
 
 # Test 3:
 # -------
-# Test if CodeDemo works correct for only checks
+# Test if CodeExercise works correct for only checks
 
 # Test 3.1
 # TODO
-# get_code_demo([single_param_check(use_fingerprint=False, failing=True, buggy=False)],
-#        include_checks=True, include_params=False)
+# get_code_exercise(
+#    [single_param_check(use_fingerprint=False, failing=True, buggy=False)],
+#    include_checks=True,
+#    include_params=False,
+# )
 
 # Test 3.2
 # TODO
-# get_code_demo([single_param_check(use_fingerprint=True, failing=True, buggy=False)],
-#        include_checks=True, include_params=False)
+# get_code_exercise(
+#    [single_param_check(use_fingerprint=True, failing=True, buggy=False)],
+#    include_checks=True,
+#    include_params=False,
+# )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -327,7 +327,7 @@ class TestAnswerWidgets:
 
         # Test 2:
         # -------
-        # Test if Textarea shows correct output
+        # Test if TextExercise shows correct output
 
         nb_cell = nb_cells[3]
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -425,7 +425,7 @@ class TestAnswerWidgets:
 
         # Test 3:
         # -------
-        # Test if CodeDemo shows correct output
+        # Test if CodeExercise shows correct output
 
         nb_cell = nb_cells[4]
 
@@ -983,7 +983,7 @@ def test_widgets_code(selenium_driver):
 
     :param selenium_driver: see conftest.py
     """
-    driver = selenium_driver("tests/notebooks/widget_code_demo.ipynb")
+    driver = selenium_driver("tests/notebooks/widget_code_exercise.ipynb")
 
     nb_cells = get_nb_cells(driver)
     # Test 1:
@@ -996,7 +996,7 @@ def test_widgets_code(selenium_driver):
         )
     )
 
-    def test_code_demo(
+    def test_code_exercise(
         nb_cell,
         expected_texts_on_update: List[str],
         expected_texts_on_check: List[str],
@@ -1164,7 +1164,7 @@ def test_widgets_code(selenium_driver):
             assert before_parameter_change_text != after_parameter_change_text
 
     # Test 1.1
-    test_code_demo(
+    test_code_exercise(
         nb_cells[2],
         ["SomeText", "Output"],
         ["Check was successful"],
@@ -1175,7 +1175,7 @@ def test_widgets_code(selenium_driver):
     )
 
     # Test 1.2
-    test_code_demo(
+    test_code_exercise(
         nb_cells[3],
         ["SomeText", "Output"],
         ["Check failed"],
@@ -1186,7 +1186,7 @@ def test_widgets_code(selenium_driver):
     )
 
     # Test 1.3
-    test_code_demo(
+    test_code_exercise(
         nb_cells[4],
         ["SomeText", "NameError: name 'bug' is not defined"],
         ["NameError: name 'bug' is not defined"],
@@ -1196,7 +1196,7 @@ def test_widgets_code(selenium_driver):
         update_mode="manual",
     )
     # Test 1.4
-    test_code_demo(
+    test_code_exercise(
         nb_cells[5],
         ["SomeText", "Output"],
         ["Check was successful"],
@@ -1207,7 +1207,7 @@ def test_widgets_code(selenium_driver):
     )
 
     # Test 1.5
-    test_code_demo(
+    test_code_exercise(
         nb_cells[6],
         ["SomeText", "Output"],
         ["Check was successful"],
@@ -1218,7 +1218,7 @@ def test_widgets_code(selenium_driver):
     )
 
     # Test 1.6
-    test_code_demo(
+    test_code_exercise(
         nb_cells[7],
         ["SomeText", "Output"],
         ["Check was successful"],
@@ -1233,7 +1233,7 @@ def test_widgets_code(selenium_driver):
 
     # Test 2.1
     # Test if update button is shown even if params are None
-    test_code_demo(
+    test_code_exercise(
         nb_cells[8],
         ["SomeText", "Output"],
         [],


### PR DESCRIPTION
* rename Textarea TextExercise
* move CodeDemo to exercise and name CodeExercise

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--39.org.readthedocs.build/en/39/

<!-- readthedocs-preview scicode-widgets end -->