### PR TITLE
Display by default not the `set_all_references_button` in the CheckRegistry

### DIFF
--- a/src/scwidgets/check/_widget_check_registry.py
+++ b/src/scwidgets/check/_widget_check_registry.py
@@ -147,11 +147,19 @@ class CheckRegistry(VBox):
         self._check_all_widgets_button = Button(description="Check all widgets")
         self._output = Output()
         kwargs["layout"] = kwargs.pop("layout", Layout(width="100%"))
+
+        self._buttons_hbox = HBox()
+
+        # needs to be after the _buttons_hbox already was created
+        self.display_set_all_references_button = kwargs.pop(
+            "display_set_all_references_button", False
+        )
+
         VBox.__init__(
             self,
             [
                 CssStyle(),
-                HBox([self._set_all_references_button, self._check_all_widgets_button]),
+                self._buttons_hbox,
                 self._output,
             ],
             *args,
@@ -169,6 +177,22 @@ class CheckRegistry(VBox):
         all registerd checks from widgets to checks
         """
         return self._checks
+
+    @property
+    def display_set_all_references_button(self) -> bool:
+        return self._display_set_all_references_button
+
+    @display_set_all_references_button.setter
+    def display_set_all_references_button(self, value: bool):
+        if value:
+            self._display_set_all_references_button = True
+            self._buttons_hbox.children = (
+                self._check_all_widgets_button,
+                self._set_all_references_button,
+            )
+        else:
+            self._display_set_all_references_button = False
+            self._buttons_hbox.children = (self._check_all_widgets_button,)
 
     @property
     def registered_widgets(self):

--- a/tests/notebooks/widget_check_registry.py
+++ b/tests/notebooks/widget_check_registry.py
@@ -27,7 +27,7 @@ from tests.test_check import single_param_check  # noqa: E402
 
 
 def create_check_registry(use_fingerprint, failing, buggy):
-    check_registry = CheckRegistry()
+    check_registry = CheckRegistry(display_set_all_references_button=True)
 
     check = single_param_check(
         use_fingerprint=use_fingerprint, failing=failing, buggy=buggy

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -979,10 +979,10 @@ def test_widget_check_registry(selenium_driver):
         """
 
         buttons = nb_cell.find_elements(By.CLASS_NAME, BUTTON_CLASS_NAME)
-        set_all_references_button = buttons[0]
-        assert set_all_references_button.get_property("title") == "Set all references"
-        check_all_widgets_button = buttons[1]
+        check_all_widgets_button = buttons[0]
         assert check_all_widgets_button.get_property("title") == "Check all widgets"
+        set_all_references_button = buttons[1]
+        assert set_all_references_button.get_property("title") == "Set all references"
 
         WebDriverWait(driver, 5).until(
             expected_conditions.element_to_be_clickable(check_all_widgets_button)


### PR DESCRIPTION
For students this is confusing, since the might overwrite the references, so there needs to be an option to disable it. Disabling it by default is a bit randomly chosen, but having less code in the student version of the code is the idea.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--44.org.readthedocs.build/en/44/

<!-- readthedocs-preview scicode-widgets end -->