### PR TITLE
Fix code is None in CodeExercise with ExerciseRegistry 

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -327,21 +327,28 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
             self._load_button = None
             self._save_cue_box = None
         else:
-            save_widgets_to_observe = [self._code]
-            save_traits_to_observe = ["function_body"]
+            save_widgets_to_observe = []
+            save_traits_to_observe = []
+
+            if self._cue_code is not None:
+                save_widgets_to_observe.append(self._code)
+                save_traits_to_observe.append("function_body")
+
             if self._parameter_panel is not None:
                 save_widgets_to_observe.extend(self._parameter_panel.parameters_widget)
                 save_traits_to_observe.extend(self._parameter_panel.parameters_trait)
-            self._cue_code = SaveCueBox(
-                save_widgets_to_observe,
-                save_traits_to_observe,
-                self._cue_code,
-                cued=True,
-            )
+
+            if self._cue_code is not None:
+                self._cue_code = SaveCueBox(
+                    save_widgets_to_observe,
+                    save_traits_to_observe,
+                    self._cue_code,
+                    cued=True,
+                )
 
             self._save_cue_box = self._cue_code
             self._save_button = SaveResetCueButton(
-                self._cue_code,
+                SaveCueBox(Box()),  # dummy cue box, because we set cues later on
                 self._on_click_save_action,
                 cued=True,
                 disable_on_successful_action=kwargs.pop(
@@ -354,7 +361,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                 button_tooltip="Loads your code and parameters from the loaded file",
             )
             self._load_button = SaveResetCueButton(
-                self._cue_code,
+                SaveCueBox(Box()),  # dummy cue box, because we set cues later on
                 self._on_click_load_action,
                 cued=True,
                 disable_on_successful_action=kwargs.pop(

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
 commands =
     # converts the python files to ipython notebooks
     jupytext tests/notebooks/*.py --to ipynb
-    pytest {posargs:-v --reruns 2} --driver Firefox
+    pytest {posargs:-v --reruns 4} --driver Firefox
 
 [testenv:tests-lab-4]
 description =
@@ -75,7 +75,7 @@ deps =
 commands =
     # converts the python files to ipython notebooks
     jupytext tests/notebooks/*.py --to ipynb
-    pytest {posargs:-v --reruns 2} -m "not matplotlib" --driver Firefox
+    pytest {posargs:-v --reruns 4} -m "not matplotlib" --driver Firefox
 
 [testenv:coverage]
 # We do coverage in a separate environment that skips the selenium tests but


### PR DESCRIPTION
When the code is None in the CodeExercise and a ExerciseRegistry is given, then an error is raised when the save cue box is created, because the cue_widget is None. Since the cue widgets are set later on, we use a dummy widget on initialization with is later replaced.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--57.org.readthedocs.build/en/57/

<!-- readthedocs-preview scicode-widgets end -->