### PR TITLE
Fix nonclearing output when nothing is outputed

### DIFF
--- a/src/scwidgets/check/_check.py
+++ b/src/scwidgets/check/_check.py
@@ -218,7 +218,9 @@ class Check:
             if self._fingerprint is not None:
                 try:
                     output = self._fingerprint(*output)
-                except Exception as exception:
+                except (  # we do not raise here since it is passed to widget output # noqa B040
+                    Exception
+                ) as exception:
                     if python_version() >= "3.11":
                         exception.add_note(
                             "An error was raised in fingerprint function, "

--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -657,6 +657,11 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                 raised_error = True
                 raise e
 
+            # The clear_output command at the beginning of the function waits till
+            # something is printed. If nothing is printed, it is not cleared. We
+            # enforce it to be invoked by printing an empty string
+            print("", end="")
+
         return not (raised_error)
 
     def run_update(self):


### PR DESCRIPTION
When the the update does not print anything the output is not cleared, since it waits for an output to be cleared. We fix this by printing an empty string to invoke the clearning of the output

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--60.org.readthedocs.build/en/60/

<!-- readthedocs-preview scicode-widgets end -->