### PR TITLE
Only create update button when update_mode manual or code input is not None

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -283,6 +283,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                         [],
                         [],
                         self._parameter_panel,
+                        cued=self._code is not None,
                     )
                 else:
                     widgets_to_observe = None
@@ -341,30 +342,35 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
             if self._cue_outputs is not None:
                 reset_update_cue_widgets.extend(self._cue_outputs)
 
-            if self._code is not None:
-                description = "Run Code"
-                button_tooltip = (
-                    "Runs the code and updates outputs with the specified parameters"
+            if self._code is not None or self._update_mode == "manual":
+                if self._code is not None:
+                    description = "Run Code"
+                    button_tooltip = (
+                        "Runs the code and updates outputs with the "
+                        "specified parameters"
+                    )
+                else:
+                    description = "Update"
+                    button_tooltip = "Updates outputs with the specified parameters"
+
+                self._update_button = UpdateResetCueButton(
+                    reset_update_cue_widgets,  # type: ignore[arg-type]
+                    self._on_click_update_action,
+                    disable_on_successful_action=kwargs.pop(
+                        "disable_update_button_on_successful_action", False
+                    ),
+                    disable_during_action=kwargs.pop(
+                        "disable_update_button_during_action",
+                        update_button_disable_during_action,
+                    ),
+                    widgets_to_observe=widgets_to_observe,
+                    traits_to_observe=traits_to_observe,
+                    description=description,
+                    button_tooltip=button_tooltip,
+                    cued=True,
                 )
             else:
-                description = "Update"
-                button_tooltip = "Updates outputs with the specified parameters"
-
-            self._update_button = UpdateResetCueButton(
-                reset_update_cue_widgets,  # type: ignore[arg-type]
-                self._on_click_update_action,
-                disable_on_successful_action=kwargs.pop(
-                    "disable_update_button_on_successful_action", False
-                ),
-                disable_during_action=kwargs.pop(
-                    "disable_update_button_during_action",
-                    update_button_disable_during_action,
-                ),
-                widgets_to_observe=widgets_to_observe,
-                traits_to_observe=traits_to_observe,
-                description=description,
-                button_tooltip=button_tooltip,
-            )
+                self._update_button = None
 
         if self._exercise_registry is None or (
             self._code is None and self._parameter_panel is None
@@ -493,6 +499,11 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
             *args,
             **kwargs,
         )
+        # In this case there is no code to be written by the student, so the code
+        # exercise should work out of the box. Since the cues for the parameters
+        # are also disabled, we update at the beginning once.
+        if self._update_mode in ["release", "continuous"] and self._code is None:
+            self.run_update()
 
     @property
     def answer(self) -> dict:
@@ -555,16 +566,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
         return self._exercise_description
 
     def _on_trait_parameters_changed(self, change: dict):
-        if self._update_button is None:
-            self._output.clear_output(wait=True)
-            error = ValueError(
-                "Invalid state: _on_trait_parameters_changed was "
-                "invoked but no update button was defined"
-            )
-            with self._output:
-                raise error
-            raise error
-        self._update_button.click()
+        self.run_update()
 
     def _on_click_check_action(self) -> bool:
         self._output.clear_output(wait=True)

--- a/tests/notebooks/widget_code_exercise.py
+++ b/tests/notebooks/widget_code_exercise.py
@@ -124,6 +124,50 @@ get_code_exercise(
 #    tunable_params=True,
 # )
 
+# Test 2.4.1 No code
+# Test if no update button and no cue is shown because the update_mode is "release"
+get_code_exercise(
+    [],
+    code=None,
+    include_checks=False,
+    include_params=True,
+    tunable_params=True,
+    update_mode="release",
+)
+
+# Test 2.4.2 No code
+# Test if no update button and no cue is shown because the update_mode is "continuous"
+get_code_exercise(
+    [],
+    code=None,
+    include_checks=False,
+    include_params=True,
+    tunable_params=True,
+    update_mode="continuous",
+)
+
+# Test 2.4.3 No code
+# Test if an update button and cue is shown because the update_mode is "manual"
+get_code_exercise(
+    [],
+    code=None,
+    include_checks=False,
+    include_params=False,
+    tunable_params=False,
+    update_mode="manual",
+)
+
+# Test 2.4.4 No code
+# Test if an update button and cue is shown because the update_mode is "manual"
+get_code_exercise(
+    [],
+    code=None,
+    include_checks=False,
+    include_params=True,
+    tunable_params=True,
+    update_mode="manual",
+)
+
 
 # Test 3:
 # -------


### PR DESCRIPTION
When no code input exists the update button should be only shown for update_mode manual.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--61.org.readthedocs.build/en/61/

<!-- readthedocs-preview scicode-widgets end -->