### PR TITLE
Fix for nested errors are not correctly resolved

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -219,7 +219,7 @@ class TestCodeExercise:
     def test_erroneous_run_code(self, code_ex):
         with pytest.raises(
             CodeValidationError,
-            match="NameError in code input: name 'bug' is not defined.*",
+            match="name 'bug' is not defined.*",
         ):
             code_ex.run_code(**code_ex.parameters)
 


### PR DESCRIPTION
When an exception is thrown within a WCI, the last frame is used as context to add the input lines. This does not work if the exception is thrown within a function within WCI. Therefore we now iterate through all traceback frames to find the one corresponding to WCI.

The corresponding PR in WCI https://github.com/osscar-org/widget-code-input/pull/26 to solve it there.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--62.org.readthedocs.build/en/62/

<!-- readthedocs-preview scicode-widgets end -->