### PR TITLE
Results of checks are now collected before handling

### DIFF
--- a/src/scwidgets/check/__init__.py
+++ b/src/scwidgets/check/__init__.py
@@ -5,12 +5,12 @@ from ._asserts import (
     assert_shape,
     assert_type,
 )
-from ._check import AssertResult, Check, ChecksResult
+from ._check import AssertResult, Check, CheckResult
 from ._widget_check_registry import CheckableWidget, CheckRegistry
 
 __all__ = [
     "Check",
-    "ChecksResult",
+    "CheckResult",
     "AssertResult",
     "CheckRegistry",
     "CheckableWidget",

--- a/src/scwidgets/check/_check.py
+++ b/src/scwidgets/check/_check.py
@@ -181,7 +181,7 @@ class Check:
     def compute_and_set_references(self):
         self._outputs_references = self.compute_outputs()
 
-    def check_function(self) -> ChecksResult:
+    def check_function(self) -> CheckResult:
         """
         Returns for each input (first depth list) the result message for each assert
         (second depth list).  If a result message is empty, the assert was successful,
@@ -199,7 +199,7 @@ class Check:
                 f"[{len(self._inputs_parameters)} != {len(self._outputs_references)}]."
             )
 
-        check_result = ChecksResult()
+        check_result = CheckResult()
         for i, input_parameters in enumerate(self._inputs_parameters):
             output = self._function_to_check(**input_parameters)
             if not (isinstance(output, tuple)):
@@ -265,7 +265,7 @@ class Check:
         return check_result
 
 
-class ChecksResult:
+class CheckResult:
     def __init__(self):
         self._assert_results = []
         self._assert_names = []
@@ -287,12 +287,6 @@ class ChecksResult:
 
         self._inputs_parameters.append(input_parameters)
         self._suppress_assert_messages.append(suppress_assert_message)
-
-    def extend(self, check_results: ChecksResult):
-        self._assert_results.extend(check_results._assert_results)
-        self._assert_names.extend(check_results._assert_names)
-        self._inputs_parameters.extend(check_results._inputs_parameters)
-        self._suppress_assert_messages.extend(check_results._suppress_assert_messages)
 
     @property
     def successful(self):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -7,7 +7,7 @@ from scwidgets.check import (
     Check,
     CheckableWidget,
     CheckRegistry,
-    ChecksResult,
+    CheckResult,
     assert_numpy_allclose,
     assert_numpy_floating_sub_dtype,
     assert_shape,
@@ -186,7 +186,7 @@ class TestCheck:
         check.compute_and_set_references()
         # now checks should be successful again
         result = check.check_function()
-        assert isinstance(result, ChecksResult)
+        assert isinstance(result, CheckResult)
         assert result.successful
 
     @pytest.mark.parametrize(
@@ -200,7 +200,7 @@ class TestCheck:
     )
     def test_failing_check_all_widgets(self, check):
         result = check.check_function()
-        assert isinstance(result, ChecksResult)
+        assert isinstance(result, CheckResult)
         assert not (result.successful)
 
     def test_invalid_asserts_arguments_count(self):
@@ -247,7 +247,7 @@ def mock_checkable_widget(check_registry, compute_output_to_check, checks=None):
             pass
 
         def handle_checks_result(self, result):
-            self.results.append(result)
+            self.results.extend(result)
 
     checkable_widget = MockCheckableWidget(check_registry)
     checkable_widget.compute_output_to_check = compute_output_to_check
@@ -285,18 +285,20 @@ class TestCheckRegistry:
 
         widgets_results = check_registry.check_all_widgets()
         nb_conducted_asserts = 0
-        for result in widgets_results.values():
-            assert isinstance(result, ChecksResult)
-            assert result.successful
-            nb_conducted_asserts += len(result.assert_results)
+        for results in widgets_results.values():
+            for result in results:
+                assert isinstance(result, CheckResult)
+                assert result.successful
+                nb_conducted_asserts += len(result.assert_results)
         assert nb_conducted_asserts == checkable_widget.nb_conducted_asserts
 
         assert len(checkable_widget.results) == len(checks)
         nb_conducted_asserts = 0
-        for result in checkable_widget.results:
-            assert isinstance(result, ChecksResult)
-            assert result.successful
-            nb_conducted_asserts += len(result.assert_results)
+        for results in widgets_results.values():
+            for result in results:
+                assert isinstance(result, CheckResult)
+                assert result.successful
+                nb_conducted_asserts += len(result.assert_results)
         assert nb_conducted_asserts == checkable_widget.nb_conducted_asserts
 
     @pytest.mark.parametrize(
@@ -323,16 +325,17 @@ class TestCheckRegistry:
         widgets_results = check_registry.check_all_widgets()
 
         nb_conducted_asserts = 0
-        for result in widgets_results.values():
-            assert isinstance(result, ChecksResult)
-            assert result.successful
-            nb_conducted_asserts += len(result.assert_results)
+        for results in widgets_results.values():
+            for result in results:
+                assert isinstance(result, CheckResult)
+                assert result.successful
+                nb_conducted_asserts += len(result.assert_results)
         assert nb_conducted_asserts == checkable_widget.nb_conducted_asserts
 
         nb_conducted_asserts = 0
         assert len(checkable_widget.results) == len(checks)
         for result in checkable_widget.results:
-            assert isinstance(result, ChecksResult)
+            assert isinstance(result, CheckResult)
             assert result.successful
             nb_conducted_asserts += len(result.assert_results)
         assert nb_conducted_asserts == checkable_widget.nb_conducted_asserts
@@ -356,11 +359,12 @@ class TestCheckRegistry:
         )
 
         widgets_results = check_registry.check_all_widgets()
-        for result in widgets_results.values():
-            assert isinstance(result, ChecksResult)
-            assert not (result.successful)
+        for results in widgets_results.values():
+            for result in results:
+                assert isinstance(result, CheckResult)
+                assert not (result.successful)
 
         assert len(checkable_widget.results) == len(checks)
         for result in checkable_widget.results:
-            assert isinstance(result, ChecksResult)
+            assert isinstance(result, CheckResult)
             assert not (result.successful)

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -6,7 +6,7 @@ import pytest
 from ipywidgets import fixed
 from widget_code_input.utils import CodeValidationError
 
-from scwidgets.check import Check, CheckRegistry, ChecksResult
+from scwidgets.check import Check, CheckRegistry, CheckResult
 from scwidgets.code import CodeInput
 from scwidgets.cue import CueObject
 from scwidgets.exercise import CodeExercise, ExerciseRegistry
@@ -157,10 +157,13 @@ class TestCodeExercise:
         ],
     )
     def test_successful_check_widget(self, code_ex):
-        result = code_ex.check()
-        assert isinstance(result, ChecksResult)
-        assert result.successful
-        assert len(result.assert_results) == code_ex.nb_conducted_asserts
+        results = code_ex.check()
+        nb_assert_results = 0
+        for result in results:
+            assert isinstance(result, CheckResult)
+            assert result.successful
+            nb_assert_results += len(result.assert_results)
+        assert nb_assert_results == code_ex.nb_conducted_asserts
 
     @pytest.mark.parametrize(
         "code_ex",
@@ -183,10 +186,13 @@ class TestCodeExercise:
     def test_compute_and_set_references(self, code_ex):
         code_ex.compute_and_set_references()
 
-        result = code_ex.check()
-        assert isinstance(result, ChecksResult)
-        assert result.successful
-        assert len(result.assert_results) == code_ex.nb_conducted_asserts
+        results = code_ex.check()
+        nb_assert_results = 0
+        for result in results:
+            assert isinstance(result, CheckResult)
+            assert result.successful
+            nb_assert_results += len(result.assert_results)
+        assert nb_assert_results == code_ex.nb_conducted_asserts
 
     @pytest.mark.parametrize(
         "code_ex",


### PR DESCRIPTION
When multiple checks were handled only the output of the last check remained. This is because all checks were individually handled and each handling cleared the output. We now collect the check result including the exceptions and then send it for handling.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--64.org.readthedocs.build/en/64/

<!-- readthedocs-preview scicode-widgets end -->