### PR TITLE
Allow checks with no inputs for property-based testing

### DIFF
--- a/src/scwidgets/check/_widget_check_registry.py
+++ b/src/scwidgets/check/_widget_check_registry.py
@@ -72,7 +72,7 @@ class CheckableWidget:
     def _add_check_from_check_parameters(
         self,
         asserts: Union[List[Check.AssertFunT], Check.AssertFunT],
-        inputs_parameters: Union[List[dict], dict],
+        inputs_parameters: Optional[Union[List[dict], dict]] = None,
         outputs_references: Optional[
             Union[List[Check.FunOutParamsT], Check.FunOutParamsT]
         ] = None,
@@ -192,7 +192,7 @@ class CheckRegistry(VBox):
         self,
         widget: CheckableWidget,
         asserts: Union[List[Check.AssertFunT], Check.AssertFunT],
-        inputs_parameters: Union[List[dict], dict],
+        inputs_parameters: Optional[Union[List[dict], dict]] = None,
         outputs_references: Optional[
             Union[List[Check.FunOutParamsT], Check.FunOutParamsT]
         ] = None,

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -70,6 +70,24 @@ def test_assert_invalid_output_parameter_dtype():
     ) in result.message()
 
 
+def no_param_check(failing):
+
+    def function_to_check(parameter):
+        print("SomeText")
+        return parameter * 2
+
+    def custom_assert() -> str:
+        # property-based tests with the student code
+        if failing:
+            return "Check does not fulfill property"
+        return ""
+
+    return Check(
+        function_to_check=function_to_check,
+        asserts=[custom_assert],
+    )
+
+
 def single_param_check(use_fingerprint=False, failing=False, buggy=False):
     if buggy:
 
@@ -175,6 +193,7 @@ class TestCheck:
     @pytest.mark.parametrize(
         "check",
         [
+            no_param_check(failing=False),
             single_param_check(use_fingerprint=False, failing=False),
             multi_param_check(use_fingerprint=False, failing=False),
             single_param_check(use_fingerprint=True, failing=False),
@@ -205,6 +224,7 @@ class TestCheck:
     @pytest.mark.parametrize(
         "check",
         [
+            no_param_check(failing=True),
             single_param_check(use_fingerprint=False, failing=True),
             multi_param_check(use_fingerprint=False, failing=True),
             single_param_check(use_fingerprint=True, failing=True),
@@ -281,6 +301,7 @@ class TestCheckRegistry:
     @pytest.mark.parametrize(
         "checks",
         [
+            [no_param_check(failing=False)],
             [
                 single_param_check(use_fingerprint=False, failing=False),
                 single_param_check(use_fingerprint=True, failing=False),
@@ -356,6 +377,7 @@ class TestCheckRegistry:
     @pytest.mark.parametrize(
         "checks",
         [
+            [no_param_check(failing=True)],
             [
                 single_param_check(use_fingerprint=False, failing=True),
                 single_param_check(use_fingerprint=True, failing=True),


### PR DESCRIPTION
For some checks the teacher might want to check behavior of the students code. In this code no inputs are needed.
TODO: test

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--67.org.readthedocs.build/en/67/

<!-- readthedocs-preview scicode-widgets end -->