### PR TITLE
Add `__call__` to `CodeInput` for easier usage

### DIFF
--- a/src/scwidgets/code/_widget_code_input.py
+++ b/src/scwidgets/code/_widget_code_input.py
@@ -5,7 +5,7 @@ import traceback
 import types
 import warnings
 from functools import wraps
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from widget_code_input import WidgetCodeInput
 from widget_code_input.utils import (
@@ -71,6 +71,9 @@ class CodeInput(WidgetCodeInput):
         Returns the unwrapped function object
         """
         return inspect.unwrap(self.get_function_object())
+
+    def __call__(self, *args, **kwargs) -> Any:
+        return self.function(*args, **kwargs)
 
     def compatible_with_signature(self, parameters: List[str]) -> str:
         """

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -78,6 +78,11 @@ class TestCodeInput:
         ):
             CodeInput(TestCodeInput.mock_function_1, code_theme="invalid_theme")
 
+    def test_call(self):
+        code = CodeInput(self.mock_function_1)
+        assert code(1, 1) == 2
+        assert code(0, 1) == 1
+
 
 def get_code_exercise(
     checks: List[Check],


### PR DESCRIPTION
The function wrapping the `CodeInput` can now be used by calling the `CodeInput` instance.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--68.org.readthedocs.build/en/68/

<!-- readthedocs-preview scicode-widgets end -->