### PR TITLE
Make figure directly accessible through `CodeExercise`

### DIFF
--- a/src/scwidgets/cue/_widget_cue_figure.py
+++ b/src/scwidgets/cue/_widget_cue_figure.py
@@ -67,6 +67,7 @@ class CueFigure(CueOutput):
         if matplotlib.backends.backend in [
             "module://matplotlib_inline.backend_inline",
             "macosx",
+            "agg",
         ]:
             # we close the figure so the figure is only contained in this widget
             # and not shown using plt.show()
@@ -104,6 +105,7 @@ class CueFigure(CueOutput):
         if matplotlib.backends.backend in [
             "module://matplotlib_inline.backend_inline",
             "macosx",
+            "agg",
         ]:
             self.clear_figure()
             self.clear_output(wait=wait)
@@ -131,6 +133,7 @@ class CueFigure(CueOutput):
         if matplotlib.backends.backend in [
             "module://matplotlib_inline.backend_inline",
             "macosx",
+            "agg",
         ]:
             with self:
                 display(self.figure)

--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -687,6 +687,15 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
     def outputs(self) -> List[CueOutput]:
         return self._cue_outputs
 
+    @property
+    def figure(self) -> Figure | None:
+        return (
+            self._cue_outputs[0].figure
+            if len(self._cue_outputs) > 0
+            and isinstance(self._cue_outputs[0], CueFigure)
+            else None
+        )
+
     def _on_click_update_action(self) -> bool:
         self._output.clear_output(wait=True)
         raised_error = False

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,9 +1,11 @@
 import os
 from typing import Callable, List, Literal, Union
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from ipywidgets import fixed
+from matplotlib.figure import Figure
 from widget_code_input.utils import CodeValidationError
 
 from scwidgets.check import Check, CheckRegistry, CheckResult
@@ -345,3 +347,11 @@ class TestCodeExercise:
                 code=TestCodeInput.mock_function_0,
                 update_func=failing_update,
             )
+
+    def test_figure(self):
+        """Test figure"""
+
+        code_ex = CodeExercise(outputs=plt.figure())
+        assert isinstance(code_ex.figure, Figure)
+        assert code_ex.output.figure is code_ex.figure
+        assert code_ex.outputs[0] is code_ex.output


### PR DESCRIPTION
If one output is only given that is translated to a `CueFigure` then it can be accessed with `code_exercise.figure` instead of `code_exercise.output.figure`

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--77.org.readthedocs.build/en/77/

<!-- readthedocs-preview scicode-widgets end -->