### PR TITLE
Support matplotlib backend "agg" for `CueFigure`

### DIFF
--- a/src/scwidgets/cue/_widget_cue_figure.py
+++ b/src/scwidgets/cue/_widget_cue_figure.py
@@ -67,6 +67,7 @@ class CueFigure(CueOutput):
         if matplotlib.backends.backend in [
             "module://matplotlib_inline.backend_inline",
             "macosx",
+            "agg",
         ]:
             # we close the figure so the figure is only contained in this widget
             # and not shown using plt.show()
@@ -104,6 +105,7 @@ class CueFigure(CueOutput):
         if matplotlib.backends.backend in [
             "module://matplotlib_inline.backend_inline",
             "macosx",
+            "agg",
         ]:
             self.clear_figure()
             self.clear_output(wait=wait)
@@ -131,6 +133,7 @@ class CueFigure(CueOutput):
         if matplotlib.backends.backend in [
             "module://matplotlib_inline.backend_inline",
             "macosx",
+            "agg",
         ]:
             with self:
                 display(self.figure)


### PR DESCRIPTION
"agg" is the terminal Linux backend, since the user should be aware that nothing can be shown in this case and raising an error prevents testing certain functionalities, we support it and do the same commands as for the "inline" backend.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--78.org.readthedocs.build/en/78/

<!-- readthedocs-preview scicode-widgets end -->