### PR TITLE
Make `CodeInput` naming related to the function object more consistent

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -756,7 +756,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                 raise ValueError(
                     "run_code was invoked, but no code was given on initializaion"
                 )
-            return self._code.run(*args, **kwargs)
+            return self._code(*args, **kwargs)
         except CodeValidationError as e:
             raise e
         except Exception as e:


### PR DESCRIPTION
Rename `get_function_object` to `wrapped_function` and make it property to be more consistent with the `function`.

In `__call__` the wrapped function is now called, this way `__call__` replaces `run` function that is removed as a consequence.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--84.org.readthedocs.build/en/84/

<!-- readthedocs-preview scicode-widgets end -->