### PR TITLE
Refactor parsing of function in `CodeInput` using `ast`

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -23,7 +23,7 @@ class TestCodeInput:
         return 0
 
     @staticmethod
-    def mock_function_1(x, y):
+    def mock_function_1(x: int, y: int = 5, z=lambda: 0):
         """
         This is an example function.
         It adds two numbers.
@@ -31,7 +31,7 @@ class TestCodeInput:
         if x > 0:
             return x + y
         else:
-            return y
+            return y + z()
 
     @staticmethod
     def mock_function_2(x):
@@ -53,26 +53,56 @@ class TestCodeInput:
     @staticmethod
     def mock_function_6(x: List[int]) -> List[int]:
         return x
+
+    @staticmethod
+    def mock_function_7(x, **kwargs):
+        return kwargs
     # fmt: on
 
-    def test_get_code(self):
+    def test_get_function_paramaters(self):
         assert (
-            CodeInput.get_code(self.mock_function_1)
-            == "if x > 0:\n    return x + y\nelse:\n    return y\n"
+            CodeInput.get_function_parameters(self.mock_function_1)
+            == "x: int, y: int = 5, z=lambda: 0"
         )
-        assert CodeInput.get_code(self.mock_function_2) == "return x\n"
-        assert CodeInput.get_code(self.mock_function_3) == "return x\n"
-        assert CodeInput.get_code(self.mock_function_4) == "return x  # noqa: E702\n"
+        assert CodeInput.get_function_parameters(self.mock_function_2) == "x"
+        assert CodeInput.get_function_parameters(self.mock_function_6) == "x: List[int]"
+        assert CodeInput.get_function_parameters(self.mock_function_7) == "x, **kwargs"
+
+    def test_get_docstring(self):
         assert (
-            CodeInput.get_code(self.mock_function_5)
+            CodeInput.get_docstring(self.mock_function_1)
+            == "\nThis is an example function.\nIt adds two numbers.\n"
+        )
+        assert (
+            CodeInput.get_docstring(self.mock_function_2)
+            == "This is an example function. It adds two numbers."
+        )
+        assert (
+            CodeInput.get_docstring(self.mock_function_2)
+            == "This is an example function. It adds two numbers."
+        )
+
+    def test_get_function_body(self):
+        assert (
+            CodeInput.get_function_body(self.mock_function_1)
+            == "if x > 0:\n    return x + y\nelse:\n    return y + z()\n"
+        )
+        assert CodeInput.get_function_body(self.mock_function_2) == "return x\n"
+        assert CodeInput.get_function_body(self.mock_function_3) == "return x\n"
+        assert (
+            CodeInput.get_function_body(self.mock_function_4)
+            == "return x  # noqa: E702\n"
+        )
+        assert (
+            CodeInput.get_function_body(self.mock_function_5)
             == "def x():\n    return 5\nreturn x()\n"
         )
-        assert CodeInput.get_code(self.mock_function_6) == "return x\n"
+        assert CodeInput.get_function_body(self.mock_function_6) == "return x\n"
         with pytest.raises(
             ValueError,
             match=r"Did not find any def definition. .*",
         ):
-            CodeInput.get_code(lambda x: x)
+            CodeInput.get_function_body(lambda x: x)
 
     def test_invalid_code_theme_raises_error(self):
         with pytest.raises(


### PR DESCRIPTION
The problem with inspect is that ignores the actual formatting provided by the user and that it sometimes stores directly the related objects (e.g. type annotation `x: int` stores the type `int` instead of the string `int` which makes it hard to pass as string later on). With `ast` this should be resolved. See example

```python
def mock_function_1(x: int, y: int):
    """
    This is an example function.
    It adds two numbers.
    """
    if x > 0:
        return x + y
    else:
        return y

import ast, inspect
module = ast.parse(inspect.getsource(mock_function_1))
ast.dump(module)

#Out: "Module(body=[FunctionDef(name='mock_function_1', args=arguments(posonlyargs=[], args=[arg(arg='x', annotation=Name(id='int', ctx=Load())), arg(arg='y', annotation=Name(id='int', ctx=Load()))], kwonlyargs=[], kw_defaults=[], defaults=[]), body=[Expr(value=Constant(value='\\n    This is an example function.\\n    It adds two numbers.\\n    ')), If(test=Compare(left=Name(id='x', ctx=Load()), ops=[Gt()], comparators=[Constant(value=0)]), body=[Return(value=BinOp(left=Name(id='x', ctx=Load()), op=Add(), right=Name(id='y', ctx=Load())))], orelse=[Return(value=Name(id='y', ctx=Load()))])], decorator_list=[])], type_ignores=[])"
```

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--86.org.readthedocs.build/en/86/

<!-- readthedocs-preview scicode-widgets end -->