### PR TITLE
Fix usage of `exercise_key` without `ExerciseRegistry`

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -176,8 +176,13 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                     "code and params do no match:  " + compatibility_result
                 )
 
-        CheckableWidget.__init__(self, check_registry, exercise_key)
-        ExerciseWidget.__init__(self, exercise_registry, exercise_key)
+        name = kwargs.get("name", exercise_key)
+        CheckableWidget.__init__(self, check_registry, name)
+        if exercise_registry is not None:
+            ExerciseWidget.__init__(self, exercise_registry, exercise_key)
+        else:
+            # otherwise ExerciseWidget constructor will raise an error
+            ExerciseWidget.__init__(self, None, None)
 
         self._code = code
         self._output = CueOutput()

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -355,3 +355,21 @@ class TestCodeExercise:
         assert isinstance(code_ex.figure, Figure)
         assert code_ex.output.figure is code_ex.figure
         assert code_ex.outputs[0] is code_ex.output
+
+    def test_consrtuction_with_registries(self):
+        """Because the exercise key is used for the `ExerciseRegistry` and the
+        `CheckRegistry` we need to ensure the `CodeExercise` can be run with
+        each individual one and both"""
+        CodeExercise(
+            exercise_key="some_key",
+            check_registry=CheckRegistry(),
+        )
+        CodeExercise(
+            exercise_key="some_key",
+            exercise_registry=ExerciseRegistry(),
+        )
+        CodeExercise(
+            exercise_key="some_key",
+            check_registry=CheckRegistry(),
+            exercise_registry=ExerciseRegistry(),
+        )


### PR DESCRIPTION
Because the `exercise_key` is used for the `ExerciseRegistry` and the `CheckRegistry` we need to ensure the `CodeExercise` can be run with each individual one and both.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--88.org.readthedocs.build/en/88/

<!-- readthedocs-preview scicode-widgets end -->