### PR TITLE
Add init argument `builtins` to `CodeInput`

### DIFF
--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -115,6 +115,25 @@ class TestCodeInput:
         assert code(1, 1) == 2
         assert code(0, 1) == 1
 
+    def test_builtins(self):
+        """Tests if import work when they are specified by builtins."""
+        import numpy as np
+
+        # to check if annotation works
+        def function(arr: np.ndarray):
+            return arr + builtins_variable  # noqa: F821
+
+        code_input = CodeInput(function, builtins={"np": np, "builtins_variable": 0})
+        code_input.unwrapped_function(np.array([0]))
+
+        # check if builtins is overwritten,
+        # the builtins_variable should not be there anymore afterwards
+        code_input.builtins = {"np": np}
+        with pytest.raises(
+            NameError, match=r".*name 'builtins_variable' is not defined.*"
+        ):
+            code_input.unwrapped_function(np.array([0]))
+
 
 def get_code_exercise(
     checks: List[Check],


### PR DESCRIPTION
This allows one to update the builtins variables when compiling the code which is necessary when the teacher wants to provide variables to the code that do not need to be created by the student.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--91.org.readthedocs.build/en/91/

<!-- readthedocs-preview scicode-widgets end -->