### PR TITLE
Fix figure not properly closed in CodeExercise with parameters

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -187,6 +187,23 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
         self._code = code
         self._output = CueOutput()
 
+        if outputs is None:
+            outputs = []
+        elif not (isinstance(outputs, list)):
+            outputs = [outputs]
+
+        self._cue_outputs: List[CueOutput] = []
+        for output in outputs:
+            if isinstance(output, Figure):
+                # This needs to happen before the creation of the
+                # ParameterPanel otherwise the figure is not properly closed. I
+                # am not sure why, I guess it is something related to interact
+                self._cue_outputs.append(CueFigure(output))
+            elif isinstance(output, CueOutput):
+                self._cue_outputs.append(output)
+            else:
+                self._cue_outputs.append(CueObject(output))
+
         self._parameter_panel: Union[ParameterPanel, None]
         if isinstance(params, dict):
             self._parameter_panel = ParameterPanel(**params)
@@ -196,20 +213,6 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
             self._parameter_panel = None
 
         self._cue_code = self._code
-
-        if outputs is None:
-            outputs = []
-        elif not (isinstance(outputs, list)):
-            outputs = [outputs]
-
-        self._cue_outputs: List[CueOutput] = []
-        for output in outputs:
-            if isinstance(output, Figure):
-                self._cue_outputs.append(CueFigure(output))
-            elif isinstance(output, CueOutput):
-                self._cue_outputs.append(output)
-            else:
-                self._cue_outputs.append(CueObject(output))
 
         if self._check_registry is None or self._code is None:
             self._check_button = None


### PR DESCRIPTION
When a CodeExercise with parameters is created and a figure is created the `<Figure size 640x480 with 0 Axes>` is displayed. This is prevented by closing the figure when `CueFigure` is created. I am not sure why this happens. It could be related to interact. It can be fixed by moving the CueFigure creation before the ParameterPanel creation.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--94.org.readthedocs.build/en/94/

<!-- readthedocs-preview scicode-widgets end -->