### PR TITLE
Ignore mypy errors related to CueWidget

### DIFF
--- a/src/scwidgets/cue/_widget_cue.py
+++ b/src/scwidgets/cue/_widget_cue.py
@@ -56,7 +56,7 @@ class CueWidget:
                             "traits_to_observe cannot contain lists when "
                             "widgets_to_observe is not a list."
                         )
-            traits_to_observe = [traits_to_observe]
+            traits_to_observe = [traits_to_observe]  # type: ignore[list-item]
         else:
             if not (isinstance(traits_to_observe, list)):
                 raise ValueError(

--- a/src/scwidgets/cue/_widget_cue_box.py
+++ b/src/scwidgets/cue/_widget_cue_box.py
@@ -37,7 +37,9 @@ class CueBox(VBox, CueWidget):
     def __init__(
         self,
         widgets_to_observe: Union[List[Widget], Widget],
-        traits_to_observe: Union[str, List[str], List[List[str]], Sentinel] = "value",
+        traits_to_observe: Union[
+            str, Sentinel, List[Union[str, Sentinel, List[str]]]
+        ] = "value",
         widget_to_cue: Optional[Widget] = None,
         cued: bool = True,
         css_style: Optional[dict] = None,
@@ -112,7 +114,9 @@ class SaveCueBox(CueBox):
     def __init__(
         self,
         widgets_to_observe: Widget,
-        traits_to_observe: Union[str, List[str], Sentinel] = "value",
+        traits_to_observe: Union[
+            str, Sentinel, List[Union[str, Sentinel, List[str]]]
+        ] = "value",
         widget_to_cue: Optional[Widget] = None,
         cued: bool = True,
         *args,
@@ -151,7 +155,9 @@ class CheckCueBox(CueBox):
     def __init__(
         self,
         widgets_to_observe: Widget,
-        traits_to_observe: Union[str, List[str], Sentinel] = "value",
+        traits_to_observe: Union[
+            str, Sentinel, List[Union[str, Sentinel, List[str]]]
+        ] = "value",
         widget_to_cue: Optional[Widget] = None,
         cued: bool = True,
         *args,
@@ -190,7 +196,9 @@ class UpdateCueBox(CueBox):
     def __init__(
         self,
         widgets_to_observe: Widget,
-        traits_to_observe: Union[str, List[str], Sentinel] = "value",
+        traits_to_observe: Union[
+            str, Sentinel, List[Union[str, Sentinel, List[str]]]
+        ] = "value",
         widget_to_cue: Optional[Widget] = None,
         cued: bool = True,
         *args,

--- a/src/scwidgets/cue/_widget_cue_figure.py
+++ b/src/scwidgets/cue/_widget_cue_figure.py
@@ -47,7 +47,7 @@ class CueFigure(CueOutput):
         figure: Figure,
         widgets_to_observe: Union[None, List[Widget], Widget] = None,
         traits_to_observe: Union[
-            None, str, List[str], List[List[str]], Sentinel
+            None, str, Sentinel, List[Union[str, Sentinel, List[str]]]
         ] = None,
         cued: bool = True,
         show_toolbars: bool = False,

--- a/src/scwidgets/cue/_widget_cue_object.py
+++ b/src/scwidgets/cue/_widget_cue_object.py
@@ -38,7 +38,7 @@ class CueObject(CueOutput):
         object: Any = None,
         widgets_to_observe: Union[None, List[Widget], Widget] = None,
         traits_to_observe: Union[
-            None, str, List[str], List[List[str]], Sentinel
+            None, str, Sentinel, List[Union[str, Sentinel, List[str]]]
         ] = None,
         cued: bool = True,
         css_style: Optional[dict] = None,

--- a/src/scwidgets/cue/_widget_cue_output.py
+++ b/src/scwidgets/cue/_widget_cue_output.py
@@ -33,7 +33,7 @@ class CueOutput(Output, CueWidget):
         self,
         widgets_to_observe: Union[None, List[Widget], Widget] = None,
         traits_to_observe: Union[
-            None, str, List[str], List[List[str]], Sentinel
+            None, str, Sentinel, List[Union[str, Sentinel, List[str]]]
         ] = None,
         cued: bool = True,
         css_style: Optional[dict] = None,

--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -302,7 +302,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
 
                     self._cue_parameter_panel = UpdateCueBox(
                         self._parameter_panel.parameters_widget,
-                        self._parameter_panel.parameters_trait,
+                        self._parameter_panel.parameters_trait,  # type: ignore
                         self._parameter_panel,
                     )
 
@@ -362,7 +362,6 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                 else:
                     description = "Update"
                     button_tooltip = "Updates outputs with the specified parameters"
-
                 self._update_button = UpdateResetCueButton(
                     reset_update_cue_widgets,  # type: ignore[arg-type]
                     self._on_click_update_action,
@@ -374,7 +373,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                         update_button_disable_during_action,
                     ),
                     widgets_to_observe=widgets_to_observe,
-                    traits_to_observe=traits_to_observe,
+                    traits_to_observe=traits_to_observe,  # type: ignore[arg-type]
                     description=description,
                     button_tooltip=button_tooltip,
                     cued=True,
@@ -403,7 +402,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
             if self._cue_code is not None:
                 self._cue_code = SaveCueBox(
                     save_widgets_to_observe,
-                    save_traits_to_observe,
+                    save_traits_to_observe,  # type: ignore[arg-type]
                     self._cue_code,
                     cued=True,
                 )


### PR DESCRIPTION
mypy cannot infer the correct type of traits_to_observe in CueWidget init constructor after if checks so we ignore it. Further there are problems with types of List[A | B] when wants to assign them with a variable of type List[A]. We ignore these cases too.

Fix types from `Union[List[str], List[Sentinel], List[List[str]]]` to `List[Union[str, Sentinel, List[str]]]`.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview scicode-widgets end -->