### PR TITLE
Restructure storage of parameters and widgets in `ParameterPanel`

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -301,8 +301,8 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                     update_button_disable_during_action = True
 
                     self._cue_parameter_panel = UpdateCueBox(
-                        self._parameter_panel.parameters_widget,
-                        self._parameter_panel.parameters_trait,  # type: ignore
+                        self._parameter_panel.panel_params_widget,
+                        self._parameter_panel.panel_params_trait,  # type: ignore
                         self._parameter_panel,
                     )
 
@@ -311,14 +311,14 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                             # TODO this has to be made public
                             cue_output._widgets_to_observe = [
                                 self._code
-                            ] + self._parameter_panel.parameters_widget
+                            ] + self._parameter_panel.panel_params_widget
                             # fmt: off
                             cue_output._traits_to_observe = (
 
                                 [  # type: ignore[assignment]
                                     "function_body"
                                 ]
-                                + self._parameter_panel.parameters_trait
+                                + self._parameter_panel.panel_params_trait
                             )
                             # fmt: on
 
@@ -326,10 +326,10 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                         else:
                             # TODO this has to be made public
                             cue_output._widgets_to_observe = (
-                                self._parameter_panel.parameters_widget
+                                self._parameter_panel.panel_params_widget
                             )
                             cue_output._traits_to_observe = (
-                                self._parameter_panel.parameters_trait  # type: ignore[assignment] # noqa: E501
+                                self._parameter_panel.panel_params_trait  # type: ignore[assignment] # noqa: E501
                             )
                             cue_output.observe_widgets()
             elif self._code is not None:
@@ -396,8 +396,10 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
                 save_traits_to_observe.append("function_body")
 
             if self._parameter_panel is not None:
-                save_widgets_to_observe.extend(self._parameter_panel.parameters_widget)
-                save_traits_to_observe.extend(self._parameter_panel.parameters_trait)
+                save_widgets_to_observe.extend(
+                    self._parameter_panel.panel_params_widget
+                )
+                save_traits_to_observe.extend(self._parameter_panel.panel_params_trait)
 
             if self._cue_code is not None:
                 self._cue_code = SaveCueBox(
@@ -535,7 +537,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
         if answer["code"] is not None and self._code is not None:
             self._code.function_body = answer["code"]
         if answer["parameter_panel"] is not None and self._parameter_panel is not None:
-            self._parameter_panel.params = answer["parameter_panel"]
+            self._parameter_panel.update_params(answer["parameter_panel"])
 
         if self._save_cue_box is not None:
             self._save_cue_box.observe_widgets()
@@ -550,10 +552,11 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
         :return: Only parameters that are tunable in the parameter panel are returned.
             Fixed parameters are ignored.
         """
-        if self._parameter_panel is not None:
-            parameter_panel = self._parameter_panel
-            return parameter_panel.panel_parameters
-        return {}
+        return (
+            {}
+            if self._parameter_panel is None
+            else self._parameter_panel.panel_parameters
+        )
 
     @property
     def params(self) -> Dict[str, Check.FunInParamT]:
@@ -561,10 +564,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
         :return: All parameters that were given on initialization are returned,
             also including also fixed parameters.
         """
-        if self._parameter_panel is not None:
-            parameter_panel = self._parameter_panel
-            return parameter_panel.params
-        return {}
+        return {} if self._parameter_panel is None else self._parameter_panel.params
 
     @property
     def exercise_title(self) -> Union[str, None]:

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -9,11 +9,21 @@ from matplotlib.figure import Figure
 from widget_code_input.utils import CodeValidationError
 
 from scwidgets.check import Check, CheckRegistry, CheckResult
-from scwidgets.code import CodeInput
+from scwidgets.code import CodeInput, ParameterPanel
 from scwidgets.cue import CueObject
 from scwidgets.exercise import CodeExercise, ExerciseRegistry
 
 from .test_check import multi_param_check, single_param_check
+
+
+class TestParameterPanel:
+
+    def test_params(self):
+        from ipywidgets import fixed
+
+        panel = ParameterPanel(**{"x": (0, 1, 0.5), "y": (2, 3, 1), "z": fixed(5)})
+        assert panel.params == {"x": 0.0, "y": 2, "z": 5}
+        assert panel.panel_params == {"x": 0.0, "y": 2}
 
 
 class TestCodeInput:


### PR DESCRIPTION
Introduce `param_to_widget_map` to access the widgets in form of a dict for more convenient handling.

To more robustly set parameter values the setter has been replaced by the `update_params` method. The setter introduced behavior that is unintuitive for python as it behaves like an update function while using assign syntax.

Alternatively a design implementing methods `__{get,set}item__`, `values` and `keys` was considered, but `keys` was clashing with the trait variable of `Widget` which would have required a different naming. This would have been more confusing.

```python
code_ex.params # returns parameter_panel
code_ex.params['x'] = 5 # works, updates the panel
code_ex.params['x']
code_ex.params.values() # works
code_ex.params.params_keys() # cannot be keys because it is already used by Widget
```

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--102.org.readthedocs.build/en/102/

<!-- readthedocs-preview scicode-widgets end -->