### PR TITLE
Add build docs github workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,32 @@
+name: Build docs 
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # Check all PR
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.11"
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - Name: Install pandoc
+      with:
+        sudo apt-get install pandoc
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: pip install tox
+
+    - name: run sphinx docs build
+      run: tox -e docs 


### PR DESCRIPTION
Until the the readthedocs hook is fixed we use this workflow to verify the doc.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--112.org.readthedocs.build/en/112/

<!-- readthedocs-preview scicode-widgets end -->