### PR TITLE
Update the check notebook

### DIFF
--- a/docs/src/check.ipynb
+++ b/docs/src/check.ipynb
@@ -41,7 +41,7 @@
    },
    "outputs": [],
    "source": [
-    "from scwidgets import CodeInput, CodeExercise, Check, CheckRegistry\n",
+    "from scwidgets import CodeInput, CodeExercise, Check, CheckRegistry, ExerciseRegistry\n",
     "\n",
     "import numpy as np "
    ]
@@ -143,11 +143,10 @@
     "    import numpy as np\n",
     "    return np.cos(arr) # oops! wrong solution\n",
     "\n",
-    "code_input_sinus = CodeInput(sinus)\n",
-    "\n",
     "check_code_ex = CodeExercise(\n",
     "    key=\"sinus_with_references_2\",\n",
-    "    code=code_input_sinus,\n",
+    "    title=\"sinus\",\n",
+    "    code=sinus,\n",
     "    check_registry=check_registry,\n",
     ")\n",
     "\n",
@@ -162,32 +161,22 @@
     "    outputs_references=[(np.asarray([0., 7.07106781e-01, 1.00000000e+00, 7.07106781e-01, 0.]),)]\n",
     ")\n",
     "\n",
-    "check_code_ex.run_check()\n",
+    "#check_code_ex.run_check()\n",
     "check_code_ex"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "10",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "print(code_input_sinus.full_function_code)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11",
-   "metadata": {},
-   "source": [
-    "One can adapt the default arguments by using partial functions"
+    "One can adapt the default arguments of the asserts by using partial functions"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "11",
    "metadata": {
     "tags": []
    },
@@ -199,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "12",
    "metadata": {
     "tags": []
    },
@@ -212,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Testing functional behavior"
@@ -221,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "14",
    "metadata": {
     "tags": []
    },
@@ -231,34 +220,32 @@
     "    import numpy as np\n",
     "    return np.cos(arr) # oops! wrong solution\n",
     "\n",
-    "code_input_sinus = CodeInput(sinus)\n",
-    "\n",
-    "check_code_ex = CodeExercise(\n",
+    "code_ex_functional_behavior = CodeExercise(\n",
     "    key=\"sinus_functional_behavior\",\n",
-    "    code=code_input_sinus,\n",
+    "    code=sinus,\n",
     "    check_registry=check_registry,\n",
     ")\n",
     "\n",
     "def assert_2pi_periodic() -> str:\n",
-    "    out = code_input_sinus.get_function_object()([0, 2*np.pi])\n",
+    "    out = code_ex_functional_behavior.code([0, 2*np.pi])\n",
     "    if not np.allclose(out[0], out[1]):\n",
     "        return \"Function is not periodic.\"\n",
     "    return \"\" # empty strings means it passes\n",
     "\n",
     "check_registry.add_check(\n",
-    "    check_code_ex,\n",
+    "    code_ex_functional_behavior,\n",
     "    asserts=[\n",
     "        assert_2pi_periodic,\n",
     "    ]\n",
     ")\n",
     "\n",
-    "check_code_ex.run_check()\n",
-    "check_code_ex"
+    "code_ex_functional_behavior.run_check()\n",
+    "code_ex_functional_behavior"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "15",
    "metadata": {
     "tags": []
    },
@@ -269,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "16",
    "metadata": {
     "tags": []
    },
@@ -320,13 +307,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
-   "metadata": {
-    "raw_mimetype": "text/markdown",
-    "tags": []
-   },
+   "id": "17",
+   "metadata": {},
    "source": [
-    "### Solution"
+    "## Checking all widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "The check registry also provides the possibility to check all the widgets. "
    ]
   },
   {
@@ -338,8 +330,7 @@
    },
    "outputs": [],
    "source": [
-    "# Once you enter the solution you can get the reference output with\n",
-    "string_to_int(check_code_ex.compute_output_to_check())"
+    "check_registry"
    ]
   },
   {
@@ -347,79 +338,16 @@
    "id": "20",
    "metadata": {},
    "source": [
-    "## Checking all widgets"
+    "For the demo to automatically we simulate a button press using the private function that should not be used"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "21",
    "metadata": {},
-   "source": [
-    "The check registry also provides the possibility to check all the widgets. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {
-    "tags": []
-   },
    "outputs": [],
    "source": [
-    "check_registry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "23",
-   "metadata": {},
-   "source": [
-    "We create a widget that will raise an error to show how this is visualized."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "24",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def error(arr):\n",
-    "    raise ValueError(\"Oops!\")\n",
-    "    return arr\n",
-    "\n",
-    "check_code_ex = CodeExercise(\n",
-    "    key=\"will_raise_error\",\n",
-    "    code=error,\n",
-    "    check_registry=check_registry,\n",
-    ")\n",
-    "\n",
-    "check_registry.add_check(\n",
-    "    check_code_ex,\n",
-    "    asserts=[\n",
-    "        assert_type,\n",
-    "    ],\n",
-    "    inputs_parameters=[{\"arr\": np.asarray([1., 2., 3.5])}],\n",
-    "    outputs_references=[(np.asarray([1., 2., 3.5]),)]\n",
-    ")\n",
-    "\n",
-    "check_code_ex.run_check()\n",
-    "check_code_ex"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "25",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# For the demo to automatically run we simulate a button press using the private function that should not be used\n",
     "check_registry._check_all_widgets_button.click()"
    ]
   }


### PR DESCRIPTION
Replace old usage of `get_function_object()(...)` with `code(...)`

Remove section that refers how to compute output for a check because it can be now just done with `code_ex.code()`.

Remove widget that raises error since it is confusing what is meant. The connection with the check registry is not made.