### PR TITLE
Fix syntax errors in the docs workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,16 +17,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - Name: Install pandoc
-      with:
-        sudo apt-get install pandoc
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install tox
+    - run: |
+        sudo apt-get install pandoc
+        pip install tox
 
-    - name: run sphinx docs build
+    - name: Build sphinx docs
       run: tox -e docs 


### PR DESCRIPTION
In PR #112 I pushed a workflow with syntax errors, because it was not shown in the PR I thought I needed to first push so the PR gets active but it was just that workflows with syntax errors are not even shown in the PR. One has to go to actions.
<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--114.org.readthedocs.build/en/114/

<!-- readthedocs-preview scicode-widgets end -->