### PR TITLE
Disable run button if no update function and parameters are given

### DIFF
--- a/src/scwidgets/exercise/_widget_code_exercise.py
+++ b/src/scwidgets/exercise/_widget_code_exercise.py
@@ -247,11 +247,7 @@ class CodeExercise(VBox, CheckableWidget, ExerciseWidget):
             )
 
         self._cue_parameters_panel = self._parameters_panel
-        if (
-            self._parameters_panel is None
-            and self._update_func is None
-            and self._code is None
-        ):
+        if self._parameters_panel is None and self._update_func is None:
             self._update_button = None
             self._cue_parameters_panel = None
         else:


### PR DESCRIPTION
The run button was still displayed in this case but could only work in case the code does not require any arguments. To enable the update button one needs now to at least provide parameters (empty in case when no parameters are needed). This enables the teacher to create exercises that are only checkable.

<!-- readthedocs-preview scicode-widgets start -->
----
📚 Documentation preview 📚: https://scicode-widgets--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview scicode-widgets end -->